### PR TITLE
chore(repo): set up commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,10 @@
+########50 characters############################
+# <type>([optional scope]): <description>
+
+########72 characters###################################################
+
+# optional body:
+
+
+# optinal footer(s):
+


### PR DESCRIPTION
Set up commit message template to make it easier for team members to follow agreed upon specification for commits.

To make sure this template is being used, execute this command in the root of the repository:
'git config commit.template .gitmessage'

NB! This template will be overridden if the -m flag is used when preforming a git commit.

For more information about the template/specification, see here: https://www.conventionalcommits.org/

Closes: #15