### PR TITLE
Removed Grabbable Script, Fixed tooltip script ref

### DIFF
--- a/Assets/Boats/Scripts.meta
+++ b/Assets/Boats/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9ef893634227fb44adc44e92e5c1996
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Boats/Scripts/SpeedboatScript.cs
+++ b/Assets/Boats/Scripts/SpeedboatScript.cs
@@ -17,7 +17,7 @@ public class SpeedboatScript : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        transform.position = new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(transform.position) *0.95f - 0.1f, transform.position.z);
+        transform.position = new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(transform.position) *0.95f - 0.05f, transform.position.z);
         //new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(transform.position), transform.position.z);
         //new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(new Vector3(transform.position.x * 16, transform.position.y, transform.position.z * 16))); 
     }

--- a/Assets/Boats/Scripts/SpeedboatScript.cs
+++ b/Assets/Boats/Scripts/SpeedboatScript.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+public class SpeedboatScript : MonoBehaviour
+{
+    // Start is called before the first frame update
+    private GameObject advancedOcean;
+    private AdvancedOcean advancedOceanScript;
+    void Start()
+    {
+        advancedOcean = GameObject.Find("Ocean");
+        advancedOceanScript = advancedOcean.GetComponent<AdvancedOcean>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        transform.position = new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(transform.position) *0.95f - 0.1f, transform.position.z);
+        //new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(transform.position), transform.position.z);
+        //new Vector3(transform.position.x, advancedOceanScript.GetWaterHeight(new Vector3(transform.position.x * 16, transform.position.y, transform.position.z * 16))); 
+    }
+}

--- a/Assets/Boats/Scripts/SpeedboatScript.cs.meta
+++ b/Assets/Boats/Scripts/SpeedboatScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2486235b21156494db898c93b4e53706
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
+++ b/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
@@ -528,6 +528,11 @@ PrefabInstance:
       propertyPath: ParentHandModel
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2109111115295015116, guid: a2419f9845db03f479057114b6bbbe86,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2109111115295015119, guid: a2419f9845db03f479057114b6bbbe86,
         type: 3}
       propertyPath: m_ConnectedAnchor.x
@@ -1074,7 +1079,7 @@ PrefabInstance:
     - target: {fileID: 3491565099550764308, guid: e4324f2703548f24eb2562d7b849cfed,
         type: 3}
       propertyPath: CanBeSnappedToSnapZone
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7808986497402078423, guid: e4324f2703548f24eb2562d7b849cfed,
         type: 3}
@@ -2091,7 +2096,7 @@ PrefabInstance:
     - target: {fileID: 394337171071851012, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 1089408208891832055, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2266,7 +2271,7 @@ PrefabInstance:
     - target: {fileID: 5223243288074044034, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5315202627171989127, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2351,7 +2356,7 @@ PrefabInstance:
     - target: {fileID: 6049354201348048514, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6214198671779282394, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2391,12 +2396,12 @@ PrefabInstance:
     - target: {fileID: 6653907717210104627, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7100381549096586012, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7531988772614831170, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2421,12 +2426,12 @@ PrefabInstance:
     - target: {fileID: 7940285738662993737, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 8071686101915463937, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 9168098935729483544, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2799,6 +2804,11 @@ PrefabInstance:
         type: 3}
       propertyPath: onLeverChange.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2109111115295015116, guid: a2419f9845db03f479057114b6bbbe86,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2109111115295015119, guid: a2419f9845db03f479057114b6bbbe86,
         type: 3}

--- a/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
+++ b/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
@@ -707,7 +707,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1108241858826004222}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -1122,7 +1122,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7114034415607929459}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -1177,7 +1177,12 @@ PrefabInstance:
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
@@ -1188,7 +1193,12 @@ PrefabInstance:
         type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 2214800855043316627}
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
@@ -1196,7 +1206,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 3061212661439654088}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
       value: SetCompleted
       objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
@@ -1206,7 +1231,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: TutorialEntry, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
+        type: 3}
+      propertyPath: onRelease.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2510300888928785696, guid: 0bff4c4331a5d094380912649ba85293,
@@ -1764,155 +1799,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1bb95e3cc47628945b87b8318f9ecdbd, type: 3}
---- !u!114 &583757599307621114 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6634091356983344526, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &633360064823039523 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6684132527669725527, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
     type: 3}
   m_PrefabInstance: {fileID: 6055347539338682228}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1108241858826004222 stripped
+--- !u!114 &3061212661439654088 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6586987899766159754, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1660654973569883036 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4828771838711497960, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5984325436733633927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &2214800855043316627 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5383040865453720807, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5079109036430693713 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1329815621130308133, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8317350174182207433
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5079109036430693713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4033a8256efb24d41ab3643fbfb83294, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnTriggered:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6311409464202709031}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  TimeoutSeconds: 8
---- !u!1 &5984325436733633927 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 505655254596381427, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2115193329563568958
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5984325436733633927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4033a8256efb24d41ab3643fbfb83294, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnTriggered:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1660654973569883036}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  TimeoutSeconds: 10
---- !u!114 &6311409464202709031 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 260729351723947859, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5079109036430693713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7114034415607929459 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3941434840542840071, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8613022740161318909 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2562389915282968713, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
+  m_CorrespondingSourceObject: {fileID: 9111756434442860476, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
     type: 3}
   m_PrefabInstance: {fileID: 6055347539338682228}
   m_PrefabAsset: {fileID: 0}
@@ -2193,6 +2088,11 @@ PrefabInstance:
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Camera, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 394337171071851012, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
     - target: {fileID: 1089408208891832055, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: OnSelected.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -2227,6 +2127,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1621867882614966556, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 2229551173557229625, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2358,6 +2263,11 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 5223243288074044034, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 5315202627171989127, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_ConnectedAnchor.x
@@ -2441,7 +2351,7 @@ PrefabInstance:
     - target: {fileID: 6049354201348048514, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 6214198671779282394, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2481,7 +2391,17 @@ PrefabInstance:
     - target: {fileID: 6653907717210104627, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7100381549096586012, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7531988772614831170, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7582204208285797886, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2501,12 +2421,12 @@ PrefabInstance:
     - target: {fileID: 7940285738662993737, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 8071686101915463937, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 9168098935729483544, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2579,7 +2499,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -2663,7 +2583,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -2753,7 +2673,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -3031,7 +2951,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8613022740161318909}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1

--- a/Assets/FishFeeding/Components/MerdCamera/Scripts/TeleportPlayerToCamera.cs
+++ b/Assets/FishFeeding/Components/MerdCamera/Scripts/TeleportPlayerToCamera.cs
@@ -46,7 +46,7 @@ public class TeleportPlayerToCamera : MonoBehaviour
     public void TeleportBack()
     {
         var playerController = BNGPlayerLocator.Instance.PlayerController;
-        playerController.transform!.SetPositionAndRotation(playerStartPosition, playerStartRotation);
+        playerController.transform.SetPositionAndRotation(playerStartPosition, playerStartRotation);
         playerController.GetComponent<PlayerGravity>().GravityEnabled = true;
 
         foreach (var (camera, layer) in cameraLayers)

--- a/Assets/FishFeeding/Components/MerdControls/Prefabs/Unified Controls/Unified-Controls--BNG.prefab
+++ b/Assets/FishFeeding/Components/MerdControls/Prefabs/Unified Controls/Unified-Controls--BNG.prefab
@@ -2901,6 +2901,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.x
       value: 11.32106
       objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}
       propertyPath: m_RootOrder
@@ -4932,6 +4937,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.x
       value: 12.32106
       objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}
       propertyPath: m_RootOrder
@@ -5518,6 +5528,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.x
       value: 13.32106
+      objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -8699,7 +8699,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 107830, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_StaticEditorFlags
-      value: 2147483647
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 459576, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_RootOrder
@@ -9198,6 +9198,24 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 2025054431}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2076327359 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 107830, guid: f980c73fa44ac5c418914faee47fe855,
+    type: 3}
+  m_PrefabInstance: {fileID: 1934614638}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2076327360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076327359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2486235b21156494db898c93b4e53706, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2099392371
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -730,6 +730,11 @@ PrefabInstance:
       propertyPath: CharacterControllerYOffset
       value: 0.25
       objectReference: {fileID: 0}
+    - target: {fileID: 4124970552446277237, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
+        type: 3}
+      propertyPath: CanDropItem
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6465843237839194327, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_TagString

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -4526,7 +4526,7 @@ PrefabInstance:
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 1760655521}
+      objectReference: {fileID: 907432592}
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
@@ -4535,12 +4535,17 @@ PrefabInstance:
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: SetCompleted
+      value: Deactivate
       objectReference: {fileID: 0}
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
       value: SetCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: TooltipScript, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
@@ -6437,7 +6442,7 @@ PrefabInstance:
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 1760655521}
+      objectReference: {fileID: 907432592}
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
@@ -6446,12 +6451,17 @@ PrefabInstance:
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: SetCompleted
+      value: Deactivate
       objectReference: {fileID: 0}
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
       value: SetCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: TooltipScript, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
@@ -6588,7 +6598,7 @@ PrefabInstance:
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 1760655521}
+      objectReference: {fileID: 907432592}
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
@@ -6597,12 +6607,17 @@ PrefabInstance:
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: SetCompleted
+      value: Deactivate
       objectReference: {fileID: 0}
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
       value: SetCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: TooltipScript, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
@@ -8000,18 +8015,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 81a7373cd7348fc4588fb2df87028154, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1760655521 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8367411518549813458, guid: fe06af38376afbc40a14204b407fd36d,
-    type: 3}
-  m_PrefabInstance: {fileID: 1330431753}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1791401734

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -327,9 +327,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1529187069}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
+      - m_Target: {fileID: 907432592}
+        m_TargetAssemblyTypeName: TooltipScript, Assembly-CSharp
+        m_MethodName: Deactivate
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1695,9 +1695,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1529187069}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
+      - m_Target: {fileID: 907432592}
+        m_TargetAssemblyTypeName: TooltipScript, Assembly-CSharp
+        m_MethodName: Deactivate
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3061,9 +3061,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1529187069}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
+      - m_Target: {fileID: 907432592}
+        m_TargetAssemblyTypeName: TooltipScript, Assembly-CSharp
+        m_MethodName: Deactivate
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4073,6 +4073,11 @@ PrefabInstance:
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
       value: TooltipScript, Assembly-CSharp
       objectReference: {fileID: 0}
+    - target: {fileID: 532289981136338383, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: Merd
+      value: 
+      objectReference: {fileID: 1696058184}
     - target: {fileID: 664265234774622822, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: Player
@@ -4519,9 +4524,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 1760655521}
+    - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
       objectReference: {fileID: 1479498688}
+    - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetCompleted
+      objectReference: {fileID: 0}
     - target: {fileID: 2746514390898159844, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
@@ -4536,6 +4551,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 1.758
+      objectReference: {fileID: 0}
+    - target: {fileID: 3019473882937995283, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3019473882937995286, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
@@ -4711,6 +4731,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3683041678773081916, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3683041679566735966, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
@@ -6410,9 +6435,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 1760655521}
+    - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
       objectReference: {fileID: 1479498688}
+    - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetCompleted
+      objectReference: {fileID: 0}
     - target: {fileID: 7984922233528063239, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
@@ -6551,9 +6586,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 1760655521}
+    - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
       objectReference: {fileID: 1479498688}
+    - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetCompleted
+      objectReference: {fileID: 0}
     - target: {fileID: 8370993154473849384, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
@@ -6679,6 +6724,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8922047417466942175, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8923946180549767615, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
       propertyPath: Merd
@@ -6803,6 +6853,9 @@ PrefabInstance:
     - {fileID: 3929101394774038227, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
     - {fileID: 3929101394659665808, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
     - {fileID: 3929101394309409273, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
+    - {fileID: 3683041678773081916, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
+    - {fileID: 3019473882937995283, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
+    - {fileID: 8922047417466942175, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: fe06af38376afbc40a14204b407fd36d, type: 3}
 --- !u!1 &1330431754 stripped
 GameObject:
@@ -7947,6 +8000,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 81a7373cd7348fc4588fb2df87028154, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1760655521 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8367411518549813458, guid: fe06af38376afbc40a14204b407fd36d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1330431753}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1791401734

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -1750,6 +1750,30 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   IsSelectedByDefault: 0
+--- !u!4 &731123466 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1347008475291580758, guid: fe06af38376afbc40a14204b407fd36d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1330431753}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &731123467 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2903838973196108509, guid: fe06af38376afbc40a14204b407fd36d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1330431753}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &731123468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 731123467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fad0fc753c69574da87f7386983a466, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &746008320
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7193,6 +7217,92 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1330431753}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1418812511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1418812512}
+  - component: {fileID: 1418812516}
+  - component: {fileID: 1418812515}
+  - component: {fileID: 1418812514}
+  - component: {fileID: 1418812513}
+  m_Layer: 0
+  m_Name: Boundaries
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1418812512
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418812511}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1934614639}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1418812513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418812511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fad0fc753c69574da87f7386983a466, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &1418812514
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418812511}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.022417214, y: 0.0026118038, z: 0.027219115}
+  m_Center: {x: -0.0006179846, y: -0.024565358, z: 0.015590305}
+--- !u!65 &1418812515
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418812511}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.026124189, y: 0.0019355391, z: 0.027219115}
+  m_Center: {x: -0.00006425077, y: 0.0187436, z: 0.015590305}
+--- !u!65 &1418812516
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418812511}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0017036004, y: 0.045510028, z: 0.027219115}
+  m_Center: {x: -0.012494766, y: -0.0030435524, z: 0.015590305}
 --- !u!114 &1479498688 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1898864050782389450, guid: fe06af38376afbc40a14204b407fd36d,
@@ -8632,6 +8742,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
+--- !u!4 &1934614639 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 459576, guid: f980c73fa44ac5c418914faee47fe855,
+    type: 3}
+  m_PrefabInstance: {fileID: 1934614638}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1950798056
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9281,6 +9397,234 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4ac7df741a9c0a2418ec19477729ee3d, type: 3}
+--- !u!23 &278164945591160431
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1443343175321736730}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &293286547054777767
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192906489986481957}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &307818950511396888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4954413670496485188}
+  - component: {fileID: 2913203824015273076}
+  - component: {fileID: 7792966661098727012}
+  - component: {fileID: 4586150743230228953}
+  m_Layer: 0
+  m_Name: Window (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &349992283624584552
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7500540647618917139}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!23 &362211272532526527
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192906489986481957}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &431025519039185930
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3586866863283621205}
+  - component: {fileID: 8145121064376483027}
+  - component: {fileID: 6047885762752558363}
+  - component: {fileID: 902592223708227687}
+  m_Layer: 0
+  m_Name: Window (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &449438090628131313
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1443343175321736730}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &556758535539205272
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192906489986481957}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 4.277, y: -0.658, z: -15.753}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!65 &902592223708227687
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431025519039185930}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &1111210856248177886
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2371052587272250128}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 4.326, y: 2.239, z: -15.753}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1001 &1126496481449260426
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9436,6 +9780,523 @@ Camera:
     type: 3}
   m_PrefabInstance: {fileID: 1126496481449260426}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1192906489986481957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 556758535539205272}
+  - component: {fileID: 293286547054777767}
+  - component: {fileID: 362211272532526527}
+  - component: {fileID: 7469946346789124728}
+  m_Layer: 0
+  m_Name: Window (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1443343175321736730
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2065389560973278506}
+  - component: {fileID: 2198817606188078050}
+  - component: {fileID: 278164945591160431}
+  - component: {fileID: 449438090628131313}
+  m_Layer: 0
+  m_Name: Window (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!33 &1576985501562502569
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7500540647618917139}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1681060523847991779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5466380283039119167}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.90909094, y: 0.90909094, z: 0.90909094}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6681895577706106838}
+  - {fileID: 4730622209877578709}
+  - {fileID: 3586866863283621205}
+  - {fileID: 4954413670496485188}
+  - {fileID: 4920498303390257610}
+  - {fileID: 5591029172339993565}
+  - {fileID: 1111210856248177886}
+  - {fileID: 2065389560973278506}
+  - {fileID: 2618194577589954571}
+  - {fileID: 3513592675469082054}
+  - {fileID: 556758535539205272}
+  m_Father: {fileID: 731123466}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2065389560973278506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1443343175321736730}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 1.928, y: 2.239, z: -15.753}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!33 &2198817606188078050
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1443343175321736730}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &2225101824443887399
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4230084472677047451}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2265631098681821756
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4730622209877578709}
+  - component: {fileID: 4637061825419373996}
+  - component: {fileID: 6367399697934420727}
+  - component: {fileID: 6289463555302596055}
+  m_Layer: 0
+  m_Name: Window (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &2371052587272250128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1111210856248177886}
+  - component: {fileID: 3200923581979136111}
+  - component: {fileID: 7225332718709171929}
+  - component: {fileID: 2738108332120812133}
+  m_Layer: 0
+  m_Name: Window (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2618194577589954571
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540213095489801067}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.052, y: -0.657, z: -12.498}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2658065094716340450
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540213095489801067}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &2738108332120812133
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2371052587272250128}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2913203824015273076
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307818950511396888}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &3200923581979136111
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2371052587272250128}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &3230713578062724482
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417305172638257520}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &3513592675469082054
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4230084472677047451}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.051, y: -0.0687, z: 0.1665}
+  m_LocalScale: {x: 0.011600001, y: 1.1689745, z: 7.249915}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &3586866863283621205
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431025519039185930}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10.272, y: 1.8797, z: -9.0558}
+  m_LocalScale: {x: 0.011600001, y: 0.869119, z: 1.1944}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4230084472677047451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3513592675469082054}
+  - component: {fileID: 7376066967631861151}
+  - component: {fileID: 5147203445650466237}
+  - component: {fileID: 2225101824443887399}
+  m_Layer: 0
+  m_Name: Window (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &4456099325103683683
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540213095489801067}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4586150743230228953
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307818950511396888}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &4637061825419373996
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265631098681821756}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &4730622209877578709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265631098681821756}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10.272, y: 1.406, z: -11.656}
+  m_LocalScale: {x: 0.011600001, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4920498303390257610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7500540647618917139}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 8.2338, y: 2.4028, z: -15.753}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!4 &4954413670496485188
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307818950511396888}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10.272, y: 1.8797, z: -7.224}
+  m_LocalScale: {x: 0.011600001, y: 0.869119, z: 1.1944}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &5147203445650466237
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4230084472677047451}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5419887011405600916
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417305172638257520}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5466380283039119167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1681060523847991779}
+  m_Layer: 0
+  m_Name: Windows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &5471793888053865229
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564831949683939214}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &5591029172339993565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417305172638257520}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 6.603, y: 2.4028, z: -15.753}
+  m_LocalScale: {x: 0.011600001, y: 1.1196, z: 0.9487806}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!23 &6047885762752558363
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431025519039185930}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6289463555302596055
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265631098681821756}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &6324571598400582057
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9525,6 +10386,357 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ab1a8d0813572b42ac21d86bbe77963, type: 3}
+--- !u!23 &6367399697934420727
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265631098681821756}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &6540213095489801067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2618194577589954571}
+  - component: {fileID: 2658065094716340450}
+  - component: {fileID: 4456099325103683683}
+  - component: {fileID: 7404233893361805749}
+  m_Layer: 0
+  m_Name: Window (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6564831949683939214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6681895577706106838}
+  - component: {fileID: 8624803488780161172}
+  - component: {fileID: 8136363088472404530}
+  - component: {fileID: 5471793888053865229}
+  m_Layer: 0
+  m_Name: Window
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6681895577706106838
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564831949683939214}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10.272, y: 1.406, z: -13.485}
+  m_LocalScale: {x: 0.011600001, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1681060523847991779}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &7225332718709171929
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2371052587272250128}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &7376066967631861151
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4230084472677047451}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &7404233893361805749
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540213095489801067}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7417305172638257520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5591029172339993565}
+  - component: {fileID: 3230713578062724482}
+  - component: {fileID: 8429495127079261745}
+  - component: {fileID: 5419887011405600916}
+  m_Layer: 0
+  m_Name: Window (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &7469946346789124728
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192906489986481957}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7500540647618917139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4920498303390257610}
+  - component: {fileID: 1576985501562502569}
+  - component: {fileID: 349992283624584552}
+  - component: {fileID: 9122968946640577916}
+  m_Layer: 0
+  m_Name: Window (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &7792966661098727012
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307818950511396888}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!23 &8136363088472404530
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564831949683939214}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8145121064376483027
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431025519039185930}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8429495127079261745
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417305172638257520}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a6bc8e0249226e54d851b67dd54da8d0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8624803488780161172
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564831949683939214}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &8754885087670771232
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9594,3 +10806,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7f02faac88351d84f855e19d20504a30, type: 3}
+--- !u!65 &9122968946640577916
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7500540647618917139}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -4924,6 +4924,11 @@ PrefabInstance:
       objectReference: {fileID: 430231559}
     - target: {fileID: 3903985382993807116, guid: fe06af38376afbc40a14204b407fd36d,
         type: 3}
+      propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3903985382993807116, guid: fe06af38376afbc40a14204b407fd36d,
+        type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: SetCompleted
       objectReference: {fileID: 0}

--- a/Assets/FishFeeding/Scripts/Hints/FishFeedHint.cs
+++ b/Assets/FishFeeding/Scripts/Hints/FishFeedHint.cs
@@ -13,8 +13,6 @@ public abstract class FishFeedHint : MonoBehaviour
     protected virtual void Start()
     {
         tutorial = GetComponentInChildren<Tutorial>();
-        triggerDelay = TimeSpan.FromSeconds(UnityEngine.Random.Range(10, 60));
-        canTriggerAt = DateTime.MaxValue;
         Debug.Assert(tutorial != null);
         if (Merd != null)
         {
@@ -25,11 +23,6 @@ public abstract class FishFeedHint : MonoBehaviour
     protected virtual void Update()
     {
         if (!tutorial.Triggered && ShouldTrigger())
-        {
-            canTriggerAt = DateTime.Now + triggerDelay;
-        }
-
-        if (canTriggerAt < DateTime.Now)
         {
             tutorial.Trigger();
             enabled = false;

--- a/Assets/FishWelfare/Scenes/FishWelfare.unity
+++ b/Assets/FishWelfare/Scenes/FishWelfare.unity
@@ -4436,7 +4436,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 107830, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_StaticEditorFlags
-      value: 2147483647
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 459576, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_RootOrder
@@ -4448,7 +4448,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 459576, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.054
+      value: -0.028
       objectReference: {fileID: 0}
     - target: {fileID: 459576, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4484,6 +4484,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f980c73fa44ac5c418914faee47fe855, type: 3}
+--- !u!1 &863913833 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 107830, guid: f980c73fa44ac5c418914faee47fe855,
+    type: 3}
+  m_PrefabInstance: {fileID: 863913832}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &863913834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863913833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2486235b21156494db898c93b4e53706, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &883530780 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7090246400861721694, guid: d9fb08c4573fa1c4e854058e411f3e8a,

--- a/Assets/FishWelfare/Scenes/FishWelfare.unity
+++ b/Assets/FishWelfare/Scenes/FishWelfare.unity
@@ -12180,6 +12180,11 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Hand
       objectReference: {fileID: 0}
+    - target: {fileID: 4124970552446277237, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
+        type: 3}
+      propertyPath: CanDropItem
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6465843237839194327, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_TagString

--- a/Assets/Ocean/Scripts/AdvancedOcean.cs
+++ b/Assets/Ocean/Scripts/AdvancedOcean.cs
@@ -15,11 +15,24 @@ public class AdvancedOcean : MonoBehaviour
         //new Wave(20, 3.5f, 0.4f, 0.8f, new Vector2(2.0f,  4.0f)),
         //new Wave(30, 2.0f, 0.4f, 0.4f, new Vector2(-1.0f, 0.0f)),
         //new Wave(10, 3.0f, 0.05f, 0.9f,new Vector2(-1.0f, 1.2f))
-        new Wave(99, 1.0f, .4f * 1.4f, 0.9f, new Vector2(1.0f,  0.2f)),
+        
+        //new Wave(99, 1.0f, .4f * 1.4f, 0.9f, new Vector2(1.0f,  0.2f)),
+        //new Wave(60, 1.2f, .4f * 0.8f, 0.5f, new Vector2(1.0f,  3.0f)),
+        //new Wave(20, 3.5f, .4f * 0.4f, 0.8f, new Vector2(2.0f,  4.0f)),
+        //new Wave(30, 2.0f, .4f * 0.4f, 0.4f, new Vector2(-1.0f, 0.0f)),
+        //new Wave(10, 3.0f, .4f * 0.05f, 0.9f,new Vector2(-1.0f, 1.2f))
+
+/*        new Wave(99, 1.0f, .4f * 10.4f, 0.9f, new Vector2(1.0f,  0.2f)),
         new Wave(60, 1.2f, .4f * 0.8f, 0.5f, new Vector2(1.0f,  3.0f)),
         new Wave(20, 3.5f, .4f * 0.4f, 0.8f, new Vector2(2.0f,  4.0f)),
-        new Wave(30, 2.0f, .4f * 0.4f, 0.4f, new Vector2(-1.0f, 0.0f)),
-        new Wave(10, 3.0f, .4f * 0.05f, 0.9f,new Vector2(-1.0f, 1.2f))
+        new Wave(30, 2.0f, .4f * 8.4f, 0.4f, new Vector2(-1.0f, 0.0f)),
+        new Wave(10, 3.0f, .4f * 0.05f, 0.9f,new Vector2(-1.0f, 1.2f))*/
+
+        new Wave(99, 1.0f, .4f * 0.07f, 0.9f, new Vector2(1.0f,  0.2f)),
+        new Wave(60, 1.2f, .4f * 0.05f, 0.5f, new Vector2(1.0f,  3.0f)),
+        new Wave(20, 3.5f, .4f * 0.065f, 0.8f, new Vector2(2.0f,  4.0f)),
+        new Wave(30, 2.0f, .4f * 0.05f, 0.4f, new Vector2(-1.0f, 0.0f)),
+        new Wave(10, 3.0f, .4f * 0.055f, 0.9f,new Vector2(-1.0f, 1.2f))
     };
     private readonly Vector4[] interactions = new Vector4[NB_INTERACTIONS];
     private int interaction_id = 0;
@@ -54,7 +67,7 @@ public class AdvancedOcean : MonoBehaviour
         interaction_id = (interaction_id + 1) % NB_INTERACTIONS;
     }
 
-    public static float GetWaterHeight(Vector3 p)
+    public float GetWaterHeight(Vector3 p)
     {
         float height = 0;
         for (int i = 0; i < NB_WAVE; i++)


### PR DESCRIPTION
Branch containing fixes to issue #187 and #188

- Removed grabbable script from all MerdButtonRound Prefabs
- Removed reference to the unused ChangeMerdHint from InnerButton OnButtonDown Event
- Added reference to the Deactivate function of the SimpleTooltip attached to the used ChangeMerdHint to the InnerButton OnButtonDown Event
  - This is how it is done with the other hint tooltips.
  - Yes, there are two ChangeMerdHint objects in the hierarchy. One is used, the other is not.