### PR TITLE
Joystick, levers and slider in pockets and objects stuck in holster

### DIFF
--- a/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
+++ b/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
@@ -528,6 +528,11 @@ PrefabInstance:
       propertyPath: ParentHandModel
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2109111115295015116, guid: a2419f9845db03f479057114b6bbbe86,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2109111115295015119, guid: a2419f9845db03f479057114b6bbbe86,
         type: 3}
       propertyPath: m_ConnectedAnchor.x
@@ -707,7 +712,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1108241858826004222}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -1074,7 +1079,7 @@ PrefabInstance:
     - target: {fileID: 3491565099550764308, guid: e4324f2703548f24eb2562d7b849cfed,
         type: 3}
       propertyPath: CanBeSnappedToSnapZone
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7808986497402078423, guid: e4324f2703548f24eb2562d7b849cfed,
         type: 3}
@@ -1122,7 +1127,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7114034415607929459}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -1188,7 +1193,7 @@ PrefabInstance:
         type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 2214800855043316627}
+      objectReference: {fileID: 0}
     - target: {fileID: 1650846086194688364, guid: 0bff4c4331a5d094380912649ba85293,
         type: 3}
       propertyPath: onGrip.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
@@ -1764,164 +1769,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1bb95e3cc47628945b87b8318f9ecdbd, type: 3}
---- !u!114 &583757599307621114 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6634091356983344526, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &633360064823039523 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6684132527669725527, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
     type: 3}
   m_PrefabInstance: {fileID: 6055347539338682228}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1108241858826004222 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6586987899766159754, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1660654973569883036 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4828771838711497960, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5984325436733633927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &2214800855043316627 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5383040865453720807, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5079109036430693713 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1329815621130308133, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8317350174182207433
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5079109036430693713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4033a8256efb24d41ab3643fbfb83294, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnTriggered:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6311409464202709031}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  TimeoutSeconds: 8
---- !u!1 &5984325436733633927 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 505655254596381427, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2115193329563568958
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5984325436733633927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4033a8256efb24d41ab3643fbfb83294, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnTriggered:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1660654973569883036}
-        m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
-        m_MethodName: SetCompleted
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  TimeoutSeconds: 10
---- !u!114 &6311409464202709031 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 260729351723947859, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5079109036430693713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7114034415607929459 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3941434840542840071, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8613022740161318909 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2562389915282968713, guid: 1bb95e3cc47628945b87b8318f9ecdbd,
-    type: 3}
-  m_PrefabInstance: {fileID: 6055347539338682228}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff29151ce177c07458d7b38725217ef6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &6829459034821879042
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2193,6 +2046,11 @@ PrefabInstance:
       propertyPath: onButtonDown.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Camera, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 394337171071851012, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1089408208891832055, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: OnSelected.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -2227,6 +2085,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1621867882614966556, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 2229551173557229625, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2358,6 +2221,11 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 5223243288074044034, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 5315202627171989127, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_ConnectedAnchor.x
@@ -2481,7 +2349,17 @@ PrefabInstance:
     - target: {fileID: 6653907717210104627, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7100381549096586012, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 7531988772614831170, guid: 1ed2b9f0db8f94646bc3551925358482,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7582204208285797886, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2501,12 +2379,12 @@ PrefabInstance:
     - target: {fileID: 7940285738662993737, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 8071686101915463937, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 9168098935729483544, guid: 1ed2b9f0db8f94646bc3551925358482,
         type: 3}
@@ -2579,7 +2457,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -2663,7 +2541,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -2753,7 +2631,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 583757599307621114}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1
@@ -2879,6 +2757,11 @@ PrefabInstance:
         type: 3}
       propertyPath: onLeverChange.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2109111115295015116, guid: a2419f9845db03f479057114b6bbbe86,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2109111115295015119, guid: a2419f9845db03f479057114b6bbbe86,
         type: 3}
@@ -3031,7 +2914,7 @@ MonoBehaviour:
   onGrip:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8613022740161318909}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TutorialEntry, Assembly-CSharp
         m_MethodName: SetCompleted
         m_Mode: 1

--- a/Assets/FishFeeding/Components/MerdControls/Prefabs/Unified Controls/Unified-Controls--BNG.prefab
+++ b/Assets/FishFeeding/Components/MerdControls/Prefabs/Unified Controls/Unified-Controls--BNG.prefab
@@ -2901,6 +2901,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.x
       value: 11.32106
       objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}
       propertyPath: m_RootOrder
@@ -4932,6 +4937,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.x
       value: 12.32106
       objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}
       propertyPath: m_RootOrder
@@ -5518,6 +5528,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.x
       value: 13.32106
+      objectReference: {fileID: 0}
+    - target: {fileID: 5955085497128414609, guid: 59ca328f577b62a4caf5c6fb849b35ef,
+        type: 3}
+      propertyPath: CanBeSnappedToSnapZone
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8496026222483879707, guid: 59ca328f577b62a4caf5c6fb849b35ef,
         type: 3}

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -730,6 +730,11 @@ PrefabInstance:
       propertyPath: CharacterControllerYOffset
       value: 0.25
       objectReference: {fileID: 0}
+    - target: {fileID: 4124970552446277237, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
+        type: 3}
+      propertyPath: CanDropItem
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6465843237839194327, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_TagString

--- a/Assets/FishWelfare/Scenes/FishWelfare.unity
+++ b/Assets/FishWelfare/Scenes/FishWelfare.unity
@@ -12180,6 +12180,11 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Hand
       objectReference: {fileID: 0}
+    - target: {fileID: 4124970552446277237, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
+        type: 3}
+      propertyPath: CanDropItem
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6465843237839194327, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_TagString


### PR DESCRIPTION
Closes issue #196 and #182 
- Turned off 'Can Be Snapped to Snap Zone'-property in the Grabbable component to joystick. levers and sliders.
- Turned on 'Can Drop Item'-property in the Snap Zone component on the left holster in the player for FishFeeding and FishWelfare scenes.

The reason objects got stuck in the left holster was because of the 'Can Drop Item'-property was turned off. This was probably done because the tablet was supposed to be stuck there. So when the tablet is added to FishFeeding and FishWelfare it needs to be turned off again. I have temporarily turned on the property so objects don't get stuck for future testing.

To prevent the fish anesthesia from continuously pouring when placed in the holster, the default orientation of the model needs to be upright and not sideways. I haven't touched the model since it is high poly and will probably be changed.