### PR TITLE
Changed from Start to Awake in Levels.cs

### DIFF
--- a/Assets/FishFeeding/Scripts/Levels.cs
+++ b/Assets/FishFeeding/Scripts/Levels.cs
@@ -14,8 +14,9 @@ public class Levels : MonoBehaviour
     private string translatedBasic;
     private string translatedAdvanced;
 
-    void Start()
+    void Awake()
     {
+        Debug.Log("Test");
         currentLevelText = GetComponentInChildren<TextMeshProUGUI>();
         modes = FindObjectOfType<Modes>();
         modes.OnModeChanged += Levels_OnModeChanged;


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
#199 
Function uses a variable set in start, before start is run.

* **What is the new behavior?** (if this is a feature change)
Variables are set in Awake instead of start, so it always runs before the function requires it

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None

* **Other information**:

