### PR TITLE
fix: levels can be toggled after fish welfare

### DIFF
--- a/Assets/FishFeeding/Components/FishSystem/Scripts/FishSystemScript.cs
+++ b/Assets/FishFeeding/Components/FishSystem/Scripts/FishSystemScript.cs
@@ -121,7 +121,7 @@ public class FishSystemScript : MonoBehaviour
 
         for (int i = 0; i < fishKilled; i++)
         {
-            gameObject.transform.GetChild(1 + i).GetComponent<FishScript>().Revive();
+            gameObject.transform.GetChild(2 + i).GetComponent<FishScript>().Revive();
         }
         fishKilled = 0;
     }

--- a/Assets/FishFeeding/Components/Modes/Scripts/ModeLoader.cs
+++ b/Assets/FishFeeding/Components/Modes/Scripts/ModeLoader.cs
@@ -31,7 +31,7 @@ public class ModeLoader : MonoBehaviour
 
     private void Start()
     {
-        DontDestroyOnLoad(gameObject);
+        //DontDestroyOnLoad(gameObject);
         LoadXML();
         StartCoroutine(AssignData());
     }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -138,6 +138,9 @@ PlayerSettings:
   preloadedAssets:
   - {fileID: 11400000, guid: 14eeaa0b6d0e01c479f1d3c024f2c7bb, type: 2}
   - {fileID: 11400000, guid: 8473e840a8157db42b96708b0020c923, type: 2}
+  - {fileID: 11400000, guid: bfa1182bd221b4ca89619141f66f1260, type: 2}
+  - {fileID: -4733715148790402427, guid: 64bb0f97eda34b24c921abfcb3c50cdb, type: 2}
+  - {fileID: 1986561998018273367, guid: a9a6963505ddf7f4d886008c6dc86122, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?**
Bug fix. 


* **What is the current behavior?**
The user is not able to toggle between basic and advanced levels after returning to fish feed after visiting fish welfare. See issue #224. I also discovered another bug which prevented the user's score from appearing after finishing a game.



* **What is the new behavior?**
The player can now toggle between basic and advanced mode after returning to fish feed from fish welfare.

* **Does this PR introduce a breaking change?**
No.


* **Other information**:
I also discovered that toggling between levels only works if the build has localization set to English. This means that all everything works if all signs have English text. This is something that must be fixed when localization is fully implemented.

