### PR TITLE
Fish factory add gill cutting

### DIFF
--- a/Assets/FishFactory/Prefabs/TempFish.prefab
+++ b/Assets/FishFactory/Prefabs/TempFish.prefab
@@ -35,6 +35,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1799158926294613224}
+  - {fileID: 2344716803455754591}
+  - {fileID: 3552668528777678409}
   m_Father: {fileID: 892177039353117103}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1467,6 +1469,202 @@ SkinnedMeshRenderer:
     m_Center: {x: -0.00015592785, y: 0.019423217, z: -0.00018240465}
     m_Extent: {x: 0.0037512907, y: 0.024295643, z: 0.005524415}
   m_DirtyAABB: 0
+--- !u!1 &6990528845072737502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3552668528777678409}
+  - component: {fileID: 5025953016431772062}
+  - component: {fileID: 1675763267509417975}
+  - component: {fileID: 1450930353565629075}
+  m_Layer: 0
+  m_Name: GillLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3552668528777678409
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6990528845072737502}
+  m_LocalRotation: {x: -0.35695282, y: -0.6103971, z: -0.35695308, w: 0.610397}
+  m_LocalPosition: {x: -0.0015670047, y: 0.0034310047, z: -0.0008600005}
+  m_LocalScale: {x: 0.0050000004, y: 0.00020000002, z: 0.005000002}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8912660782349489306}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -60.637, y: -90, z: 0}
+--- !u!33 &5025953016431772062
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6990528845072737502}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1675763267509417975
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6990528845072737502}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1450930353565629075
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6990528845072737502}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 0.5000004
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.00000005960468, y: 0, z: -0.000000089407024}
+--- !u!1 &8344248835457177312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2344716803455754591}
+  - component: {fileID: 2185598480939993153}
+  - component: {fileID: 7397609930443720410}
+  - component: {fileID: 2566232244686987091}
+  m_Layer: 0
+  m_Name: GillRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2344716803455754591
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344248835457177312}
+  m_LocalRotation: {x: -0.40738425, y: 0.5779605, z: -0.40738407, w: -0.5779603}
+  m_LocalPosition: {x: 0.0011800021, y: 0.0038500053, z: -0.0007399991}
+  m_LocalScale: {x: 0.004999998, y: 0.00019999997, z: 0.005}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8912660782349489306}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 70.357, y: -90, z: 0}
+--- !u!33 &2185598480939993153
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344248835457177312}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7397609930443720410
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344248835457177312}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &2566232244686987091
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344248835457177312}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 0.5000004
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.00000005960468, y: 0, z: -0.000000089407024}
 --- !u!1 &8949009753926357334
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Prefabs/TempFish.prefab
+++ b/Assets/FishFactory/Prefabs/TempFish.prefab
@@ -106,7 +106,7 @@ ConfigurableJoint:
     bounciness: 0
     contactDistance: 0
   m_HighAngularXLimit:
-    limit: 56.6
+    limit: -73.63
     bounciness: 0
     contactDistance: 0
   m_AngularYZLimitSpring:
@@ -117,7 +117,7 @@ ConfigurableJoint:
     bounciness: 0
     contactDistance: 0
   m_AngularZLimit:
-    limit: 43.8
+    limit: 3
     bounciness: 0
     contactDistance: 0
   m_TargetPosition: {x: 0, y: 0, z: 0}
@@ -750,6 +750,7 @@ GameObject:
   - component: {fileID: 7629873390220260630}
   - component: {fileID: 4409538153559368249}
   - component: {fileID: 1631902393193195089}
+  - component: {fileID: 8558291684313983748}
   m_Layer: 0
   m_Name: Bone.002
   m_TagString: Bone
@@ -1056,6 +1057,19 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &8558291684313983748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3789406318523307031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d263eb4712b2824db63728839c2e321, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fishState: {fileID: 4708518783950727776}
 --- !u!1 &5904361523580772602
 GameObject:
   m_ObjectHideFlags: 0
@@ -1071,6 +1085,7 @@ GameObject:
   - component: {fileID: 2803777293659360099}
   - component: {fileID: 5165582754977071724}
   - component: {fileID: 7693275070032131098}
+  - component: {fileID: 693576795148650945}
   m_Layer: 0
   m_Name: Bone.001
   m_TagString: Bone
@@ -1377,6 +1392,19 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &693576795148650945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5904361523580772602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d263eb4712b2824db63728839c2e321, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fishState: {fileID: 4708518783950727776}
 --- !u!1 &6761250684236006651
 GameObject:
   m_ObjectHideFlags: 0
@@ -1481,6 +1509,7 @@ GameObject:
   - component: {fileID: 5025953016431772062}
   - component: {fileID: 1675763267509417975}
   - component: {fileID: 1450930353565629075}
+  - component: {fileID: 7189870065385868617}
   m_Layer: 0
   m_Name: GillLeft
   m_TagString: Untagged
@@ -1495,9 +1524,9 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6990528845072737502}
-  m_LocalRotation: {x: -0.35695282, y: -0.6103971, z: -0.35695308, w: 0.610397}
-  m_LocalPosition: {x: -0.0015670047, y: 0.0034310047, z: -0.0008600005}
-  m_LocalScale: {x: 0.0050000004, y: 0.00020000002, z: 0.005000002}
+  m_LocalRotation: {x: -0.35695282, y: -0.6103972, z: -0.35695308, w: 0.610397}
+  m_LocalPosition: {x: -0.0015670062, y: 0.0034310082, z: -0.0008600007}
+  m_LocalScale: {x: 0.0049999994, y: 0.00020000004, z: 0.0050000027}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8912660782349489306}
@@ -1518,7 +1547,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6990528845072737502}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -1531,7 +1560,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 05cd1700f942c804e9fa9c9ebb3b5b30, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1567,6 +1596,18 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0.00000005960468, y: 0, z: -0.000000089407024}
+--- !u!114 &7189870065385868617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6990528845072737502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 721d196e533c8b04dabea81e3dd9bd46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8344248835457177312
 GameObject:
   m_ObjectHideFlags: 0
@@ -1579,6 +1620,7 @@ GameObject:
   - component: {fileID: 2185598480939993153}
   - component: {fileID: 7397609930443720410}
   - component: {fileID: 2566232244686987091}
+  - component: {fileID: 3493797855565589226}
   m_Layer: 0
   m_Name: GillRight
   m_TagString: Untagged
@@ -1593,9 +1635,9 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8344248835457177312}
-  m_LocalRotation: {x: -0.40738425, y: 0.5779605, z: -0.40738407, w: -0.5779603}
-  m_LocalPosition: {x: 0.0011800021, y: 0.0038500053, z: -0.0007399991}
-  m_LocalScale: {x: 0.004999998, y: 0.00019999997, z: 0.005}
+  m_LocalRotation: {x: -0.40738413, y: 0.57796055, z: -0.407384, w: -0.57796025}
+  m_LocalPosition: {x: 0.0011800029, y: 0.0038500086, z: -0.0007399991}
+  m_LocalScale: {x: 0.0049999976, y: 0.00019999997, z: 0.005000001}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8912660782349489306}
@@ -1616,7 +1658,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8344248835457177312}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -1665,6 +1707,18 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0.00000005960468, y: 0, z: -0.000000089407024}
+--- !u!114 &3493797855565589226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344248835457177312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 721d196e533c8b04dabea81e3dd9bd46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8949009753926357334
 GameObject:
   m_ObjectHideFlags: 0
@@ -1782,6 +1836,7 @@ GameObject:
   - component: {fileID: 1108904297938659368}
   - component: {fileID: 6969006045870410308}
   - component: {fileID: 3926386766273583588}
+  - component: {fileID: 5115140814727245601}
   m_Layer: 0
   m_Name: Bone.003
   m_TagString: Bone
@@ -2087,3 +2142,16 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &5115140814727245601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9186388590370930684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d263eb4712b2824db63728839c2e321, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fishState: {fileID: 4708518783950727776}

--- a/Assets/FishFactory/Prefabs/TempFish.prefab
+++ b/Assets/FishFactory/Prefabs/TempFish.prefab
@@ -1526,7 +1526,7 @@ Transform:
   m_GameObject: {fileID: 6990528845072737502}
   m_LocalRotation: {x: -0.35695282, y: -0.6103972, z: -0.35695308, w: 0.610397}
   m_LocalPosition: {x: -0.0015670062, y: 0.0034310082, z: -0.0008600007}
-  m_LocalScale: {x: 0.0049999994, y: 0.00020000004, z: 0.0050000027}
+  m_LocalScale: {x: 0.005706997, y: 0.003, z: 0.005707001}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8912660782349489306}
@@ -1608,6 +1608,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 721d196e533c8b04dabea81e3dd9bd46, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fishState: {fileID: 4708518783950727776}
 --- !u!1 &8344248835457177312
 GameObject:
   m_ObjectHideFlags: 0
@@ -1637,7 +1638,7 @@ Transform:
   m_GameObject: {fileID: 8344248835457177312}
   m_LocalRotation: {x: -0.40738413, y: 0.57796055, z: -0.407384, w: -0.57796025}
   m_LocalPosition: {x: 0.0011800029, y: 0.0038500086, z: -0.0007399991}
-  m_LocalScale: {x: 0.0049999976, y: 0.00019999997, z: 0.005000001}
+  m_LocalScale: {x: 0.005706997, y: 0.003, z: 0.005707001}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8912660782349489306}
@@ -1719,6 +1720,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 721d196e533c8b04dabea81e3dd9bd46, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fishState: {fileID: 4708518783950727776}
 --- !u!1 &8949009753926357334
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Prefabs/TempKnife.prefab
+++ b/Assets/FishFactory/Prefabs/TempKnife.prefab
@@ -1,0 +1,187 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3770499158709355761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 777637915580049087}
+  - component: {fileID: 4788981634775860639}
+  - component: {fileID: 2879617807025085628}
+  - component: {fileID: 1228757856296911041}
+  - component: {fileID: 1507291875413471640}
+  - component: {fileID: 730174119461237654}
+  m_Layer: 0
+  m_Name: TempKnife
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &777637915580049087
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.880587, y: -1.3085212, z: -7.7147417}
+  m_LocalScale: {x: 0.01, y: 0.2, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4788981634775860639
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2879617807025085628
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1228757856296911041
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1507291875413471640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cdea428d48e2bb488d33d5f75c39bb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BeingHeld: 0
+  GrabButton: 2
+  Grabtype: 2
+  GrabPhysics: 4
+  GrabMechanic: 1
+  GrabSpeed: 15
+  RemoteGrabbable: 0
+  RemoteGrabMechanic: 0
+  RemoteGrabDistance: 2
+  ThrowForceMultiplier: 2
+  ThrowForceMultiplierAngular: 1.5
+  BreakDistance: 0
+  HideHandGraphics: 0
+  ParentToHands: 0
+  ParentHandModel: 1
+  SnapHandModel: 1
+  CanBeDropped: 1
+  CanBeSnappedToSnapZone: 1
+  ForceDisableKinematicOnDrop: 0
+  InstantMovement: 0
+  MakeChildCollidersGrabbable: 0
+  handPoseType: 1
+  SelectedHandPose: {fileID: 0}
+  CustomHandPose: 0
+  SecondaryGrabBehavior: 0
+  TwoHandedPosition: 0
+  TwoHandedPostionLerpAmount: 0.5
+  TwoHandedRotation: 1
+  TwoHandedRotationLerpAmount: 0.5
+  TwoHandedDropBehavior: 0
+  TwoHandedLookVector: 0
+  SecondHandLookSpeed: 40
+  SecondaryGrabbable: {fileID: 0}
+  OtherGrabbableMustBeGrabbed: {fileID: 0}
+  CollisionSpring: 3000
+  CollisionSlerp: 500
+  CollisionLinearMotionX: 2
+  CollisionLinearMotionY: 2
+  CollisionLinearMotionZ: 2
+  CollisionAngularMotionX: 2
+  CollisionAngularMotionY: 2
+  CollisionAngularMotionZ: 2
+  ApplyCorrectiveForce: 1
+  MoveVelocityForce: 3000
+  MoveAngularVelocityForce: 90
+  LastGrabTime: 0
+  LastDropTime: 0
+  AddControllerVelocityOnDrop: 1
+  collisions: []
+  ActiveGrabPoint: {fileID: 0}
+  SecondaryLookOffset: {x: 0, y: 0, z: 0}
+  SecondaryLookAtTransform: {fileID: 0}
+  LocalOffsetTransform: {fileID: 0}
+  GrabPoints: []
+  UseCustomInspector: 1
+  lastFlickTime: 0
+  FlickForce: 1
+--- !u!54 &730174119461237654
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3770499158709355761}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/FishFactory/Prefabs/TempKnife.prefab.meta
+++ b/Assets/FishFactory/Prefabs/TempKnife.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1a3505fe9214abc48995e1b12cc99607
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scripts/BadCutting.cs
+++ b/Assets/FishFactory/Scripts/BadCutting.cs
@@ -14,8 +14,6 @@ public class BadCutting : MonoBehaviour
             return;
         }
 
-        Debug.Log("bad with " + collisionObject.gameObject.name);
-
         fishState.BadCut();
     }
 }

--- a/Assets/FishFactory/Scripts/BadCutting.cs
+++ b/Assets/FishFactory/Scripts/BadCutting.cs
@@ -17,6 +17,5 @@ public class BadCutting : MonoBehaviour
         Debug.Log("bad with " + collisionObject.gameObject.name);
 
         fishState.BadCut();
-        GameManager.instance.Score -= 1;
     }
 }

--- a/Assets/FishFactory/Scripts/BadCutting.cs
+++ b/Assets/FishFactory/Scripts/BadCutting.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BadCutting : MonoBehaviour
+{
+    [SerializeField]
+    private FactoryFishState fishState;
+
+    private void OnCollisionEnter(Collision collisionObject)
+    {
+        if (collisionObject.gameObject.tag != "Knife")
+        {
+            return;
+        }
+
+        Debug.Log("bad with " + collisionObject.gameObject.name);
+
+        fishState.BadCut();
+        GameManager.instance.Score -= 1;
+    }
+}

--- a/Assets/FishFactory/Scripts/BadCutting.cs.meta
+++ b/Assets/FishFactory/Scripts/BadCutting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d263eb4712b2824db63728839c2e321
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scripts/FactoryFishState.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishState.cs
@@ -9,10 +9,19 @@ public class FactoryFishState : MonoBehaviour
         Alive,
         Stunned,
         Bleeding,
-        Dead
+        Dead,
+        BadCut
     }
 
     public State currentState;
+
+    public void CutGills()
+    {
+        currentState = State.Bleeding;
+    }
+
+    public void BadCut()
+    {
+        currentState = State.BadCut;
+    }
 }
-
-

--- a/Assets/FishFactory/Scripts/FactoryFishState.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishState.cs
@@ -17,11 +17,42 @@ public class FactoryFishState : MonoBehaviour
 
     public void CutGills()
     {
-        currentState = State.Bleeding;
+        switch (currentState)
+        {
+            case State.Alive:
+                currentState = State.Bleeding; // The player should get negative points for cutting the gills of a not stunned fish
+                GameManager.instance.Score -= 1;
+                break;
+
+            case State.Stunned:
+                currentState = State.Bleeding;
+                GameManager.instance.Score += 1;
+                break;
+
+            case State.BadCut:
+                currentState = State.Bleeding; // The player should not recieve points for cutting the gills of a fish that has already been cut incorrectly
+                break;
+
+            default:
+                // Possible states: Bleeding, Dead
+                // The player should not be able to cut the gills of a fish that is dead/bad or already bleeding
+                break;
+        }
     }
 
     public void BadCut()
     {
+        // To make the cutting process more forgiving, we will not penalize the player for a bad cut if the fish is already cut correctly
+        // The player will only be penalized for a bad cut if the fish is alive or has not been cut yet
+        if (
+            currentState == State.Bleeding
+            || currentState == State.Dead
+            || currentState == State.BadCut
+        )
+        {
+            return;
+        }
         currentState = State.BadCut;
+        GameManager.instance.Score -= 1;
     }
 }

--- a/Assets/FishFactory/Scripts/GameManager.cs
+++ b/Assets/FishFactory/Scripts/GameManager.cs
@@ -17,12 +17,23 @@ public class GameManager : MonoBehaviour
         get { return isTaskOn; }
     }
 
+    private int score = 0;
+    public int Score
+    {
+        get { return score; }
+        set { score = value; }
+    }
+
+    void Update()
+    {
+        Debug.Log("score " + score);
+    }
+
     void Awake()
     {
         // Sets the instance of the GameManager to this object if it does not already exist
         if (instance == null)
             instance = this;
-
 
         // Makes the GameManager object persist between scenes
         DontDestroyOnLoad(gameObject);

--- a/Assets/FishFactory/Scripts/GillCutting.cs
+++ b/Assets/FishFactory/Scripts/GillCutting.cs
@@ -14,8 +14,6 @@ public class GillCutting : MonoBehaviour
             return;
         }
 
-        Debug.Log("gill with " + collisionObject.name);
-
         fishState.CutGills();
     }
 }

--- a/Assets/FishFactory/Scripts/GillCutting.cs
+++ b/Assets/FishFactory/Scripts/GillCutting.cs
@@ -16,10 +16,6 @@ public class GillCutting : MonoBehaviour
 
         Debug.Log("gill with " + collisionObject.name);
 
-        //FIXME: Make this prettier
-        // Get the fish object
-
         fishState.CutGills();
-        GameManager.instance.Score += 1;
     }
 }

--- a/Assets/FishFactory/Scripts/GillCutting.cs
+++ b/Assets/FishFactory/Scripts/GillCutting.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GillCutting : MonoBehaviour
+{
+    [SerializeField]
+    private FactoryFishState fishState;
+
+    private void OnTriggerEnter(Collider collisionObject)
+    {
+        if (collisionObject.tag != "Knife")
+        {
+            return;
+        }
+
+        Debug.Log("gill with " + collisionObject.name);
+
+        //FIXME: Make this prettier
+        // Get the fish object
+
+        fishState.CutGills();
+        GameManager.instance.Score += 1;
+    }
+}

--- a/Assets/FishFactory/Scripts/GillCutting.cs.meta
+++ b/Assets/FishFactory/Scripts/GillCutting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 721d196e533c8b04dabea81e3dd9bd46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -23,6 +23,7 @@ TagManager:
   - BoatTransitionToFeeding
   - Title
   - OcupationName
+  - Knife
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introduces gill cutting in bleeding station

* **What is the current behavior?** (You can also link to an open issue here)
#272 

* **What is the new behavior?** (if this is a feature change)
The player is able to cut the fish, both in the body and in the gills

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
As of now the score is updated in the GameManager through the console, but should later be changed to give feedback to the player. The cutting of gills can feel a bit odd, related to the current "jiggliness" of the fish object. The hitbox of the gills can be further expanded to make the gillcutting easier. Feedback on the cutting should also be implemented later.
