### PR TITLE
Added EmulatorOffsetEnabler from base VR4VET repo

### DIFF
--- a/Assets/VR4VET/Components/Player/Prefab/XR Rig Advanced VR4VET.prefab
+++ b/Assets/VR4VET/Components/Player/Prefab/XR Rig Advanced VR4VET.prefab
@@ -10089,6 +10089,18 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 4951666920190502304}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &3318179840408000107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6465843237839194327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d38635b7948daa4449f52ce192e8fa11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7028846462367453588 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2683195716791022644, guid: 4ac7df741a9c0a2418ec19477729ee3d,

--- a/Assets/VR4VET/Components/Player/Scripts.meta
+++ b/Assets/VR4VET/Components/Player/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 169b1856336b7a54eb7df8c51558a17d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VR4VET/Components/Player/Scripts/EmulatorOffsetEnabler.cs
+++ b/Assets/VR4VET/Components/Player/Scripts/EmulatorOffsetEnabler.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using BNG;
+using UnityEngine.XR.Management;
+
+public class EmulatorOffsetEnabler : MonoBehaviour
+{
+    private bool _hmdExists;
+    private PlayerTeleport _teleportScript;
+    // Start is called before the first frame update
+    void Start()
+    {
+        _teleportScript = GetComponent<PlayerTeleport>();
+        _hmdExists = XRGeneralSettings.Instance.Manager.activeLoader != null;
+        if(!_hmdExists)
+        {
+            _teleportScript.TeleportYOffset = 1.5f;
+        }
+    }
+}

--- a/Assets/VR4VET/Components/Player/Scripts/EmulatorOffsetEnabler.cs.meta
+++ b/Assets/VR4VET/Components/Player/Scripts/EmulatorOffsetEnabler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d38635b7948daa4449f52ce192e8fa11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
#365 

* **What is the new behavior?** (if this is a feature change)
Now checks if emulator is active, and moves player upwards on teleport to offset the missing height from not having a HMD connected

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

