### PR TITLE
feat: implement logic for displaying fish tiers and logic for sorting…

### DIFF
--- a/Assets/FishFactory/Scenes/QAStation.unity
+++ b/Assets/FishFactory/Scenes/QAStation.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1474,6 +1474,117 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 155879039}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &165989171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 165989176}
+  - component: {fileID: 165989175}
+  - component: {fileID: 165989174}
+  - component: {fileID: 165989173}
+  - component: {fileID: 165989172}
+  m_Layer: 0
+  m_Name: Cube (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &165989172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165989171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 307855cbfcdad7c429887c5cbd4f198c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  successfullGuttingCheck: 0
+--- !u!65 &165989173
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165989171}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &165989174
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165989171}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 83227e8a33a09214aa44fadf4883636e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &165989175
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165989171}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &165989176
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165989171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.5229, y: 0.687, z: -10.6866}
+  m_LocalScale: {x: 0.4228062, y: 0.3089879, z: 0.6822851}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &179372721
 GameObject:
   m_ObjectHideFlags: 0
@@ -2692,15 +2803,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isSpawnerOn: 1
-  fishPrefab: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
-    type: 3}
+  fishPrefab: {fileID: 0}
   maxAmountOfFish: 5
-  randomFishStateChance: 0
-  fishAliveChance: 4
   spawnRate: 3.81
   varationInSpawnrate: 1.41
   fishSizeVariation: 1
+  aliveFishPercent: 10
+  badFishPercent: 10
   toggleFishTier: 0
+  fishPrefabTier2: {fileID: 0}
+  fishPrefabTier3: {fileID: 0}
+  tier1Percentage: 25
+  tier2Percentage: 50
+  toggleFishGuttingChance: 0
+  successfullGuttingChance: 80
+  incompleteGuttingChance: 80
 --- !u!65 &415939426
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -3251,8 +3368,46 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
         type: 3}
+      propertyPath: toggleFishTier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: fishPrefabTier2
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: fishPrefabTier3
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: spawnedFishPrefab
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
       propertyPath: randomFishStateChance
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: incompleteGuttingChance
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: toggleFishGuttingChance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: successfullGuttingChance
+      value: 65
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0520bc6499befc448814690dd287e41f, type: 3}
@@ -5001,7 +5156,7 @@ PrefabInstance:
     - target: {fileID: 2721307927523674537, guid: 367ebf8f553f2394a9cd4efb13db05ab,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2721307927523674537, guid: 367ebf8f553f2394a9cd4efb13db05ab,
         type: 3}
@@ -8405,6 +8560,117 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 993287043}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1002498025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1002498030}
+  - component: {fileID: 1002498029}
+  - component: {fileID: 1002498028}
+  - component: {fileID: 1002498027}
+  - component: {fileID: 1002498026}
+  m_Layer: 0
+  m_Name: Cube (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1002498026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002498025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 307855cbfcdad7c429887c5cbd4f198c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  successfullGuttingCheck: 1
+--- !u!65 &1002498027
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002498025}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1002498028
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002498025}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 83227e8a33a09214aa44fadf4883636e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1002498029
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002498025}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1002498030
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002498025}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 9.802, y: 0.886, z: -9.77}
+  m_LocalScale: {x: 0.4228062, y: 0.3089879, z: 0.6822851}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &1013772708
 GameObject:
   m_ObjectHideFlags: 0
@@ -9117,7 +9383,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -9134,7 +9399,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 1078507754}
   belt: {fileID: 1078507752}
 --- !u!23 &1078507754
@@ -9817,7 +10083,7 @@ PrefabInstance:
     - target: {fileID: 4234165376520476066, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4234165376520476066, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
@@ -14648,7 +14914,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -14665,7 +14930,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 1758888811}
   belt: {fileID: 1758888809}
 --- !u!23 &1758888811
@@ -17774,6 +18040,44 @@ PrefabInstance:
       propertyPath: fishTier
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: toggleFishTier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: fishPrefabTier2
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: fishPrefabTier3
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: spawnedFishPrefab
+      value: 
+      objectReference: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+        type: 3}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: incompleteGuttingChance
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: toggleFishGuttingChance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8956598537416962814, guid: 0520bc6499befc448814690dd287e41f,
+        type: 3}
+      propertyPath: successfullGuttingChance
+      value: 65
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0520bc6499befc448814690dd287e41f, type: 3}
 --- !u!4 &470784465159553483 stripped
@@ -20056,7 +20360,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 2601781502276952384}
   belt: {fileID: 4408375495284214832}
 --- !u!114 &2727241744679909353
@@ -20071,7 +20376,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 2601781501734961785}
   belt: {fileID: 4408375496888151817}
 --- !u!114 &2727241744916490203
@@ -20086,7 +20392,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 2601781501901558347}
   belt: {fileID: 4408375496854994747}
 --- !u!33 &2861229796330441083
@@ -20117,7 +20424,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -20180,7 +20486,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 3864527601375578471}
   belt: {fileID: 3213141540427441175}
 --- !u!65 &3827079683414630105
@@ -20611,7 +20918,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -20628,7 +20934,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -20645,7 +20950,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -20971,7 +21275,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32358fca128a10444aa60462a95ccf29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameManager: {fileID: 0}
   isBeltOn: 1
   acceleration: 30
   maxSpeed: 0.5
@@ -22153,7 +22456,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f47e24a3a139741b9f349556b8d913, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scrollSpeed: 0.08
+  scrollSpeedX: 0.1
+  scrollSpeedY: 0
   rend: {fileID: 8548873049417822918}
   belt: {fileID: 8040441472385818550}
 --- !u!1 &8738353655597782923

--- a/Assets/FishFactory/Scripts/FactoryFishSpawner.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishSpawner.cs
@@ -10,7 +10,7 @@ public class FactoryFishSpawner : MonoBehaviour
     private bool isSpawnerOn = true;
 
     [SerializeField]
-    [Tooltip("The gameobject prefab to spawn")]
+    [Tooltip("The gameobject prefab to spawn. This prefab will be used as the tier 1 fish if fish tiers are enabeled")]
     private GameObject fishPrefab;
 
     [SerializeField]
@@ -50,6 +50,14 @@ public class FactoryFishSpawner : MonoBehaviour
     private bool toggleFishTier;
 
     [SerializeField]
+    [Tooltip("The gameobject prefab to spawn if fish is tier 2")]
+    private GameObject fishPrefabTier2;
+
+    [SerializeField]
+    [Tooltip("The gameobject prefab to spawn if fish is tier 3")]
+    private GameObject fishPrefabTier3;
+
+    [SerializeField]
     [Range(0, 100)]
     [Tooltip("The percentage of fish that should be Tier 1. Higher number equals higher chance.")]
     private int tier1Percentage = 25;
@@ -60,6 +68,21 @@ public class FactoryFishSpawner : MonoBehaviour
         "The percentage of fish that should be Tier 2. Higher number equals higher chance. The remaining percentage will be Tier 3."
     )]
     private int tier2Percentage = 50;
+
+    [Header("Fish Gutting Settings")]
+    [SerializeField]
+    [Tooltip("If toggled, the fish will be assigned a state defining if it has been successfully gutted or not")]
+    private bool toggleFishGuttingChance;
+
+    [SerializeField]
+    [Range(0, 100)]
+    [Tooltip("The percentage of fish that should be successfully gutted")]
+    private int successfullGuttingChance = 65;
+
+    [SerializeField]
+    [Range(0, 100)]
+    [Tooltip("The percentage of fish that are not completely gutted")]
+    private int incompleteGuttingChance = 25;
 
     // ------------------ Private Variables ------------------
 
@@ -128,14 +151,39 @@ public class FactoryFishSpawner : MonoBehaviour
 
         if (currentAmountOfFish < maxAmountOfFish && isSpawnerOn)
         {
+            GameObject spawnedFishPrefab = fishPrefab;
+            string fishTag = "fish";
+
+            // Randomizes the quality of the fish if enabled. The fish will be tagged with the tier it belongs to.
+            if (toggleFishTier)
+            {
+                int randomValue = Random.Range(1, 101);
+                if (randomValue <= tier1Percentage)
+                {
+                    fishTag = "Tier1";
+                    spawnedFishPrefab = fishPrefab;
+                }
+                else if (randomValue <= tier1Percentage + tier2Percentage)
+                {
+                    fishTag = "Tier2";
+                    spawnedFishPrefab = fishPrefabTier2;
+                }
+                else
+                {
+                    fishTag = "Tier3";
+                    spawnedFishPrefab = fishPrefabTier3;
+                }
+            }
+
             // Spawn object as a child of the spawner object, and as such limit the amount of spawned objects to increase performance.
             GameObject childGameObject = Instantiate(
-                fishPrefab,
+                spawnedFishPrefab,
                 transform.position,
                 Random.rotation,
                 transform
             );
             childGameObject.name = "FactoryFish" + transform.childCount.ToString();
+            childGameObject.tag = fishTag;
 
             // Randomizes the state of the fish
             FactoryFishState fishState = childGameObject.GetComponent<FactoryFishState>();
@@ -153,24 +201,6 @@ public class FactoryFishSpawner : MonoBehaviour
                     randomSize,
                     randomSize
                 );
-            }
-
-            // Randomizes the quality of the fish if enabled. The fish will be tagged with the tier it belongs to.
-            if (toggleFishTier)
-            {
-                int randomValue = Random.Range(1, 101);
-                if (randomValue <= tier1Percentage)
-                {
-                    childGameObject.tag = "Tier1";
-                }
-                else if (randomValue <= tier1Percentage + tier2Percentage)
-                {
-                    childGameObject.tag = "Tier2";
-                }
-                else
-                {
-                    childGameObject.tag = "Tier3";
-                }
             }
         }
 
@@ -207,6 +237,23 @@ public class FactoryFishSpawner : MonoBehaviour
         int randomValue = Random.Range(1, 101);
 
         FactoryFishState.State state;
+
+        if (toggleFishGuttingChance)
+        {
+            if (randomValue <= successfullGuttingChance)
+            {
+                state = FactoryFishState.State.GuttingSuccess;
+            }
+            else if (randomValue <= successfullGuttingChance + incompleteGuttingChance)
+            {
+                state = FactoryFishState.State.GuttingIncomplete;
+            }
+            else
+            {
+                state = FactoryFishState.State.GuttingFailure;  
+            }
+            return state;
+        }
 
         if (randomValue <= aliveFishPercent)
         {

--- a/Assets/FishFactory/Scripts/FactoryFishState.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishState.cs
@@ -9,7 +9,10 @@ public class FactoryFishState : MonoBehaviour
         Stunned,
         Bleeding,
         BadQuality,
-        BadCut
+        BadCut,
+        GuttingSuccess,
+        GuttingIncomplete,
+        GuttingFailure,
     }
 
     // The current public state of the fish.

--- a/Assets/FishFactory/Scripts/GuttingFishSorting.cs
+++ b/Assets/FishFactory/Scripts/GuttingFishSorting.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GuttingFishSorting : MonoBehaviour
+{
+    [SerializeField]
+    [Tooltip("If toggled, the trigger will give correct if fish has state GuttingSuccess. If not it will give correct for GuttingIncomplete state")]
+    private bool successfullGuttingCheck;
+
+    // ------------------ Private Variables ------------------
+
+    // Counts the amount correctly and incorrectly sorted fish
+    private int successfullySortedFish;
+    private int incorrectlySortedFish;
+
+    // ------------------ Unity Functions ------------------
+
+    private void OnTriggerEnter(Collider collisionObject)
+    {
+        if (collisionObject.tag != "Destroyable")
+        {
+            return;
+        }
+        // Get the main fish object
+        GameObject fish = collisionObject.transform.parent.gameObject.transform.parent.gameObject;
+        // Get fish state and check if fish is alive, if fish is alive it's state is set to stunned
+        FactoryFishState fishState = fish.GetComponent<FactoryFishState>();
+
+        if (successfullGuttingCheck)
+        {
+            if (fishState.currentState == FactoryFishState.State.GuttingSuccess)
+            {
+                GameManager.Instance.PlaySound("correct");
+                successfullySortedFish++;
+                return;
+            }
+        }
+        else
+        {
+            if (fishState.currentState == FactoryFishState.State.GuttingIncomplete)
+            {
+                GameManager.Instance.PlaySound("correct");
+                successfullySortedFish++;
+                return;
+            }
+        }
+        GameManager.Instance.PlaySound("incorrect");
+        incorrectlySortedFish++;
+    }
+}

--- a/Assets/FishFactory/Scripts/GuttingFishSorting.cs.meta
+++ b/Assets/FishFactory/Scripts/GuttingFishSorting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 307855cbfcdad7c429887c5cbd4f198c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
… gutted fish

implement swiching of fish prefabs depending on fish tiers. Add logic for sorting gutted fish

close: #296 and #404

<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
Fish all look the same regardless of tier. There is no checks if gutted fish is sorted correctly. See issues #296 and #404 

* **What is the new behavior?** (if this is a feature change)
Fish can now be given separate prefabs depending on tier. Gutted fish is given a state and the state gets checked after passing the sorting stage.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
none
