### PR TITLE
feat: add logic for displaying bad fish and alive fish and add feedba…

### DIFF
--- a/Assets/FishFactory/Scenes/BleedingStation.unity
+++ b/Assets/FishFactory/Scenes/BleedingStation.unity
@@ -2105,9 +2105,16 @@ MonoBehaviour:
   fishSizeVariation: 1
   aliveFishPercent: 10
   badFishPercent: 10
+  badfishPrefab: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+    type: 3}
   toggleFishTier: 0
+  fishPrefabTier2: {fileID: 0}
+  fishPrefabTier3: {fileID: 0}
   tier1Percentage: 25
   tier2Percentage: 50
+  toggleFishGuttingChance: 0
+  successfullGuttingChance: 65
+  incompleteGuttingChance: 25
 --- !u!1001 &150855736
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2789,9 +2796,16 @@ MonoBehaviour:
   fishSizeVariation: 1
   aliveFishPercent: 10
   badFishPercent: 10
+  badfishPrefab: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+    type: 3}
   toggleFishTier: 0
+  fishPrefabTier2: {fileID: 0}
+  fishPrefabTier3: {fileID: 0}
   tier1Percentage: 25
   tier2Percentage: 50
+  toggleFishGuttingChance: 0
+  successfullGuttingChance: 65
+  incompleteGuttingChance: 25
 --- !u!1001 &200893554
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22664,9 +22678,16 @@ MonoBehaviour:
   fishSizeVariation: 1
   aliveFishPercent: 10
   badFishPercent: 10
+  badfishPrefab: {fileID: 2435888089390791047, guid: 876825a9ca87ae343a886434bb014069,
+    type: 3}
   toggleFishTier: 0
+  fishPrefabTier2: {fileID: 0}
+  fishPrefabTier3: {fileID: 0}
   tier1Percentage: 25
   tier2Percentage: 50
+  toggleFishGuttingChance: 0
+  successfullGuttingChance: 65
+  incompleteGuttingChance: 25
 --- !u!1001 &951503706
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Scripts/DiscardBadFish.cs
+++ b/Assets/FishFactory/Scripts/DiscardBadFish.cs
@@ -12,7 +12,11 @@ public class DiscardBadFish : MonoBehaviour
     public int DestroyFishTreshold{ get {return destroyFishTreshold;}}
     private int nrFishDiscarded = 0;
     public int NrFishDiscarded{ get {return nrFishDiscarded;}}
-    
+    private int incorrectlyDiscardedFish = 0;
+    public int IncorrectlyDiscardedFish{ get {return incorrectlyDiscardedFish;}}
+    private int correctlyDiscardedFish = 0;
+    public int CorrectlyDiscardedFish{ get {return correctlyDiscardedFish;}}
+
     // list of fish that are currently stunned
     private List<GameObject> discardedFish = new List<GameObject>();
     private void OnTriggerEnter(Collider collisionObject)
@@ -25,7 +29,22 @@ public class DiscardBadFish : MonoBehaviour
         if (!discardedFish.Contains(fish.gameObject)) 
         {
             discardedFish.Add(fish.gameObject);
-            if (discardedFish.Count >= destroyFishTreshold){
+
+            // Check if the fish should have been discarded or not, and give the user feedback
+            if (fishState.currentState == FactoryFishState.State.BadQuality)
+            {
+                GameManager.Instance.PlaySound("correct");
+                correctlyDiscardedFish++;
+            }
+            else
+            {
+                GameManager.Instance.PlaySound("incorrect");
+                incorrectlyDiscardedFish--;
+            }
+
+            // Delete fish if number of fish in bin is larger than destroyFishTreshold
+            if (discardedFish.Count >= destroyFishTreshold)
+            {
                 GameObject fishDelete = discardedFish[0];
                 discardedFish.RemoveAt(0);
                 Destroy(fishDelete);

--- a/Assets/FishFactory/Scripts/FactoryFishSpawner.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishSpawner.cs
@@ -44,6 +44,10 @@ public class FactoryFishSpawner : MonoBehaviour
     )]
     private int badFishPercent = 10;
 
+    [SerializeField]
+    [Tooltip("The gameobject prefab to spawn if fish is bad or dead and should be thrown away")]
+    private GameObject badfishPrefab;
+
     [Header("Fish Tier Settings")]
     [SerializeField]
     [Tooltip("If toggled, the fish will spawn in different tiers")]
@@ -175,6 +179,13 @@ public class FactoryFishSpawner : MonoBehaviour
                 }
             }
 
+            // Get a random state and sets prefab to badfishPrefab if the state is BadQuality
+            FactoryFishState.State randomizedFishState = RandomizeFishState();
+            if (randomizedFishState == FactoryFishState.State.BadQuality) 
+            {
+                spawnedFishPrefab = badfishPrefab;
+            }
+
             // Spawn object as a child of the spawner object, and as such limit the amount of spawned objects to increase performance.
             GameObject childGameObject = Instantiate(
                 spawnedFishPrefab,
@@ -183,14 +194,24 @@ public class FactoryFishSpawner : MonoBehaviour
                 transform
             );
             childGameObject.name = "FactoryFish" + transform.childCount.ToString();
-            childGameObject.tag = fishTag;
+            
+            if (toggleFishTier)
+            {
+                childGameObject.tag = fishTag;
+            }
 
-            // Randomizes the state of the fish
+            // Set the state of the fish to the randomizedFishState
             FactoryFishState fishState = childGameObject.GetComponent<FactoryFishState>();
             if (fishState != null)
             {
-                fishState.currentState = RandomizeFishState();
+                fishState.currentState = randomizedFishState;
             }
+
+            // Enable animator if fish is alive (disabled as fish animations are not functional)
+            /* if(randomizedFishState == FactoryFishState.State.Alive)
+            {
+                childGameObject.GetComponent<Animator>().enabled = true;
+            } */
 
             // Randomizes the size of the fish if enabled
             if (fishSizeVariation)


### PR DESCRIPTION
…ck to the discarding prefab

allow for a separate prefab to be used if the fish has state bad quality and toggle on the animator if fish has state alive (comented out). logic is added to the discarding box to give user audio feedback

close: #287 and #411

<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
No separate way to display a bad / dead fish and discard box give the user no feedback. See issues #411 and #287 

* **What is the new behavior?** (if this is a feature change)
A separate fish prefab can be assigned to bad fish and audio feedback along with a new point system has been added to the discarding box prefab. Also some comented out logic for enabling animation on fish that are alive have also been added.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
none
