### PR TITLE
feat: improve sanitizer and boot scrubber

### DIFF
--- a/Assets/FishFactory/Resources/Materials/ff-sanitizer1.mat
+++ b/Assets/FishFactory/Resources/Materials/ff-sanitizer1.mat
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ff-sanitizer1
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords:
+  - _NORMALMAP
+  - _PARALLAXMAP
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 2800000, guid: f0b2f9a6890ef004785be63dec86401f, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 2800000, guid: ed712a0093482ef4ba158b397bbf381d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: de9e347b4c7e3134c979f61362fe552e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 2800000, guid: f0b2f9a6890ef004785be63dec86401f, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 2800000, guid: 19d8813c85a63a0498a00e9df37c5392, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0.178
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.0396
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.9811321, g: 0.9811321, b: 0.9811321, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/FishFactory/Resources/Materials/ff-sanitizer1.mat.meta
+++ b/Assets/FishFactory/Resources/Materials/ff-sanitizer1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 983d32725f6dd2341a4bc797fababd17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scenes/HSERoom.unity
+++ b/Assets/FishFactory/Scenes/HSERoom.unity
@@ -6916,6 +6916,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -180
       objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 6da67a8b3b2f771489f33ef96260f1c1,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 983d32725f6dd2341a4bc797fababd17, type: 2}
     - target: {fileID: 919132149155446097, guid: 6da67a8b3b2f771489f33ef96260f1c1,
         type: 3}
       propertyPath: m_Name
@@ -7662,6 +7667,18 @@ MonoBehaviour:
   - {fileID: 2100000, guid: e411184659f2c154ba0c58b7e03a28e6, type: 2}
   - {fileID: 2100000, guid: a440b3c946e562140a920a019a73e3a6, type: 2}
   - {fileID: 2100000, guid: a32adf19c2f6a804abce8f893b89751c, type: 2}
+--- !u!114 &819638194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819638181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be206c8e628132f4a95bcae76c169a6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &833063735
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27675,6 +27692,178 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1743504156}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1764562180
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1764562181}
+  - component: {fileID: 1764562183}
+  - component: {fileID: 1764562182}
+  m_Layer: 0
+  m_Name: SantizerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1764562181
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764562180}
+  m_LocalRotation: {x: 0.6830127, y: 0.6830127, z: 0.18301274, w: 0.18301274}
+  m_LocalPosition: {x: 0, y: 0, z: 0.017536808}
+  m_LocalScale: {x: 0.0018990713, y: 0.0013174175, z: 0.0017941344}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 728408221}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 150, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00845778, y: 0.0129522085}
+  m_SizeDelta: {x: 27.1028, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1764562182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764562180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Sanitizer
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294926336
+  m_fontColor: {r: 0, g: 0.37569666, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1764562183}
+  m_maskType: 0
+--- !u!23 &1764562183
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764562180}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1769428599 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 2ab8fccced56b5448906a69cb627fd9e,
@@ -40479,7 +40668,7 @@ MonoBehaviour:
   GrabPhysics: 0
   GrabMechanic: 1
   GrabSpeed: 15
-  RemoteGrabbable: 0
+  RemoteGrabbable: 1
   RemoteGrabMechanic: 0
   RemoteGrabDistance: 2
   ThrowForceMultiplier: 2

--- a/Assets/FishFactory/Scripts/HSERoom/BootsState.cs
+++ b/Assets/FishFactory/Scripts/HSERoom/BootsState.cs
@@ -32,6 +32,8 @@ public class BootsState : MonoBehaviour
     [SerializeField]
     private int scrubbingLeft = 5;
 
+    private float scrubbingDuration = 0f;
+
     [Tooltip(
         "The materials that will be used to change the boots' appearance. Should be 'dirty', 'soaped', 'semisoaped', 'clean', in that order."
     )]
@@ -44,6 +46,7 @@ public class BootsState : MonoBehaviour
     /// Check if the boots are scrubbed with the scrubber. Only checks for "collisions" with the scrubber object.
     /// </summary>
     /// <param name="collision">The scrubber object</param>
+    /*
     void OnCollisionEnter(Collision collision)
     {
         if (collision.gameObject.name == "Scrubber" && boots == BootsStatus.SemiClean)
@@ -51,6 +54,28 @@ public class BootsState : MonoBehaviour
             // Could add sound effect here
             scrubbingLeft--;
             if (scrubbingLeft < 0)
+            {
+                boots = BootsStatus.Clean;
+                GameManager.Instance.PlaySound("correct");
+                gameObject.GetComponent<MeshRenderer>().material = materials[3]; // Clean
+            }
+        }
+    }
+    */
+
+    private void OnCollisionStay(Collision collision)
+    {
+        if (collision.gameObject.name == "Scrubber" && boots == BootsStatus.SemiClean)
+        {
+            scrubbingDuration += Time.deltaTime; // Track scrubbing duration
+            // Calculate scrubbing progress based on time
+            int scrubbingProgress = Mathf.FloorToInt(
+                scrubbingDuration / soakingTime * scrubbingLeft
+            );
+            // Reduce scrubbing left based on time
+            scrubbingLeft = Mathf.Max(0, scrubbingLeft - scrubbingProgress);
+
+            if (scrubbingLeft <= 0)
             {
                 boots = BootsStatus.Clean;
                 GameManager.Instance.PlaySound("correct");

--- a/Assets/FishFactory/Scripts/HSERoom/EquipBoots.cs
+++ b/Assets/FishFactory/Scripts/HSERoom/EquipBoots.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class EquipBoots : MonoBehaviour
+{
+    /// <summary>
+    /// When the player's feet collide with the boots, equip them
+    /// </summary>
+    /// <param name="collision">The player's feet collider</param>
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (
+            collision.gameObject.tag == "Player"
+            && gameObject.GetComponent<BootsState>().Boots == BootsState.BootsStatus.Clean
+        )
+        {
+            GameManager.Instance.BootsOn = true;
+            GameManager.Instance.PlaySound("correct");
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/FishFactory/Scripts/HSERoom/EquipBoots.cs.meta
+++ b/Assets/FishFactory/Scripts/HSERoom/EquipBoots.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be206c8e628132f4a95bcae76c169a6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Slight changed color and texure on hand sanitizer for visibilty, also added text to it saying "sanitizer" to remove all doubt. added EquipBoots script and changed the scrubbing logic to no longer bonk, but use OnCollisionStay

refs: #431, #432

<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
better boot scrubbing, sanitizer visibilty change

* **What is the current behavior?** (You can also link to an open issue here)
bonk boots to clean, no equip

* **What is the new behavior?** (if this is a feature change)
clean boots by scrubbing, equip boots, text on sanitizer

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

