### PR TITLE
Fish factory gutting sorting test

### DIFF
--- a/Assets/FishFactory/Scenes/QAStation.unity
+++ b/Assets/FishFactory/Scenes/QAStation.unity
@@ -3570,7 +3570,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 307855cbfcdad7c429887c5cbd4f198c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _successOnGuttingSuccess: 0
+  _successOnGuttingSuccess: 6
 --- !u!65 &165989173
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -18009,7 +18009,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 307855cbfcdad7c429887c5cbd4f198c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _successOnGuttingSuccess: 1
+  _successOnGuttingSuccess: 5
 --- !u!65 &1002498027
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Scripts/Bleeding/CutFish.cs
+++ b/Assets/FishFactory/Scripts/Bleeding/CutFish.cs
@@ -12,7 +12,8 @@ public class CutFish : MonoBehaviour
     void Start()
     {
         GameObject knife = GameObject.Find("FishKnife");
-        _knifeState = knife.GetComponent<KnifeState>();
+        if (knife)
+            _knifeState = knife.GetComponent<KnifeState>();
     }
 
     protected void cutEvent(string tag, bool isGills = false)

--- a/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
+++ b/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
@@ -9,7 +9,11 @@ public class GuttingFishSorting : MonoBehaviour
         "If toggled, the trigger will give correct if fish has state GuttingSuccess. If not it will give correct for GuttingIncomplete state"
     )]
     public FactoryFishState.State _successOnGuttingSuccess;
-
+    private List<int> _sortedFish = new List<int>();
+    public int SortedFishCount
+    { 
+        get { return _sortedFish.Count;}
+    }
     // ------------------ Unity Functions ------------------
 
     /// <summary>
@@ -25,7 +29,17 @@ public class GuttingFishSorting : MonoBehaviour
             return;
         }
 
-        if (checkFishState(FactoryFishState.State.GuttingSuccess, fish))
+        if (!_sortedFish.Contains(fish.gameObject.GetInstanceID()))
+        {
+            _sortedFish.Add(fish.gameObject.GetInstanceID());
+        }
+        if (GameManager.Instance != null)
+            HandleAudioFeedback(fish.GetComponent<FactoryFishState>());
+    }
+
+     private void HandleAudioFeedback(FactoryFishState fishState)
+    {
+        if (checkFishState(_successOnGuttingSuccess, fishState.gameObject))
         {
             GameManager.Instance.PlaySound("correct");
         }
@@ -34,6 +48,7 @@ public class GuttingFishSorting : MonoBehaviour
             GameManager.Instance.PlaySound("incorrect");
         }
     }
+
 
     // ---------------- Private Functions ------------------
 

--- a/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
+++ b/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
@@ -5,9 +5,6 @@ using UnityEngine;
 public class GuttingFishSorting : MonoBehaviour
 {
     [SerializeField]
-    [Tooltip(
-        "If toggled, the trigger will give correct if fish has state GuttingSuccess. If not it will give correct for GuttingIncomplete state"
-    )]
     public FactoryFishState.State _successOnGuttingSuccess;
     private List<int> _sortedFish = new List<int>();
     public int SortedFishCount
@@ -39,7 +36,7 @@ public class GuttingFishSorting : MonoBehaviour
 
      private void HandleAudioFeedback(FactoryFishState fishState)
     {
-        if (checkFishState(_successOnGuttingSuccess, fishState.gameObject))
+        if (checkFishState(fishState.gameObject))
         {
             GameManager.Instance.PlaySound("correct");
         }
@@ -56,10 +53,10 @@ public class GuttingFishSorting : MonoBehaviour
     /// Check if the state of the fish is the same as the success condition.
     /// Play a sound based on the result.
     /// </summary>
-    public bool checkFishState(FactoryFishState.State successCondition, GameObject fish)
+    public bool checkFishState(GameObject fish)
     {
         FactoryFishState fishState = fish.GetComponent<FactoryFishState>();
-        if (fishState.CurrentState == successCondition)
+        if (fishState.CurrentState == _successOnGuttingSuccess)
         {
         return true;
         }

--- a/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
+++ b/Assets/FishFactory/Scripts/Gutting/GuttingFishSorting.cs
@@ -8,7 +8,7 @@ public class GuttingFishSorting : MonoBehaviour
     [Tooltip(
         "If toggled, the trigger will give correct if fish has state GuttingSuccess. If not it will give correct for GuttingIncomplete state"
     )]
-    private bool _successOnGuttingSuccess = true;
+    public FactoryFishState.State _successOnGuttingSuccess;
 
     // ------------------ Unity Functions ------------------
 
@@ -25,13 +25,13 @@ public class GuttingFishSorting : MonoBehaviour
             return;
         }
 
-        if (_successOnGuttingSuccess)
+        if (checkFishState(FactoryFishState.State.GuttingSuccess, fish))
         {
-            checkFishState(FactoryFishState.State.GuttingSuccess, fish);
+            GameManager.Instance.PlaySound("correct");
         }
         else
         {
-            checkFishState(FactoryFishState.State.GuttingIncomplete, fish);
+            GameManager.Instance.PlaySound("incorrect");
         }
     }
 
@@ -41,16 +41,16 @@ public class GuttingFishSorting : MonoBehaviour
     /// Check if the state of the fish is the same as the success condition.
     /// Play a sound based on the result.
     /// </summary>
-    private void checkFishState(FactoryFishState.State successCondition, GameObject fish)
+    public bool checkFishState(FactoryFishState.State successCondition, GameObject fish)
     {
         FactoryFishState fishState = fish.GetComponent<FactoryFishState>();
         if (fishState.CurrentState == successCondition)
         {
-            GameManager.Instance.PlaySound("correct");
+        return true;
         }
         else
         {
-            GameManager.Instance.PlaySound("incorrect");
+        return false;
         }
     }
 }

--- a/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs
+++ b/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs
@@ -49,20 +49,18 @@ public class GuttingFishSortingTest
     [UnityTest]
     public IEnumerator SortGuttingSuccess()
     {
-        int SuccessFullSorts = 0;
         foreach (FactoryFishState.State state in Enum.GetValues(typeof(FactoryFishState.State)))
         {
             Fish.GetComponent<FactoryFishState>().CurrentState = state;
             SortingScript._successOnGuttingSuccess = FactoryFishState.State.GuttingSuccess;
-            if (SortingScript.checkFishState(FactoryFishState.State.GuttingSuccess, Fish))
-                SuccessFullSorts++;
+            if (Fish.GetComponent<FactoryFishState>().CurrentState == FactoryFishState.State.GuttingSuccess)
+                Assert.AreEqual(true, SortingScript.checkFishState(Fish));
+            else
+                Assert.AreEqual(false, SortingScript.checkFishState(Fish));
         }
-        Assert.AreEqual(
-            1,
-            SuccessFullSorts
-        );
         yield return null;
     }
+    [OneTimeTearDown]
     public void OneTimeTearDown()
     {
         UnityEngine.Object.Destroy(Fish);

--- a/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs
+++ b/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+
+public class GuttingFishSortingTest
+{
+    private const string TestSceneName = "GuttingFishSortingTests";
+    private GameObject Fish;
+    private GameObject Sorter;
+    private GuttingFishSorting SortingScript;
+
+    // A Test behaves as an ordinary method
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+       // create a new test scene
+       SceneManager.CreateScene(TestSceneName);
+
+       // Load and instantiate the prefabs
+       var fishPrefab = Resources.Load<GameObject>("Prefabs/Fish/FishFactorySalmon");
+       Fish = Object.Instantiate(fishPrefab);
+       Fish.transform.position = new Vector3(10, 10, 10);
+       Sorter = GameObject.CreatePrimitive(PrimitiveType.Cube);
+       Sorter.transform.position = new Vector3(0, 0, 0);
+       BoxCollider SorterTrigger = Sorter.AddComponent<BoxCollider>();
+       SorterTrigger.isTrigger = true;
+       SortingScript = Sorter.AddComponent<GuttingFishSorting>();
+        
+    }
+
+    // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
+    // `yield return null;` to skip a frame.
+    [UnityTest]
+    public IEnumerator SortGuttingSuccess()
+    {
+        Fish.GetComponent<FactoryFishState>().CurrentState = FactoryFishState.State.GuttingSuccess;
+        SortingScript._successOnGuttingSuccess = FactoryFishState.State.GuttingSuccess;
+       Assert.AreEqual(
+        true,
+        SortingScript.checkFishState(FactoryFishState.State.GuttingSuccess, Fish)
+       );
+
+        yield return null;
+    }
+    public void OneTimeTearDown()
+    {
+        Object.Destroy(Fish);
+        Object.Destroy(Sorter);
+        SceneManager.UnloadSceneAsync(TestSceneName);
+    }
+}

--- a/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs.meta
+++ b/Assets/FishFactory/Tests/PlayMode/GuttingFishSortingTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcd3ac0f204dc1e46be41ee809bcf4fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
adds a unit test for the GuttingFishSorting.cs

* **What is the current behavior?** (You can also link to an open issue here)
the test automatically fails in this branch but should not be a problem if #485 is merged aswell

* **What is the new behavior?** (if this is a feature change)
altered GuttingFishSorting.cs to make sure the collision does not register the same fish as sorted twice similar to how the DiscardBadFish.cs script does, and then testing that it works properly with a test.
Tests the GuttingFishSorting.cs by running the sorting method (which is now a bool) against all possible inputs and checking that only the expected input returns true

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
#485 should be merged first
