### PR TITLE
Speak button fixes

### DIFF
--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -24,6 +24,8 @@ public class DialogueBoxController : MonoBehaviour
     [HideInInspector] private Animator _animator;
     [HideInInspector] private int _isTalkingHash;
     [HideInInspector] private int _hasNewDialogueOptionsHash;
+    [HideInInspector] private RectTransform backgroundRect;
+    [HideInInspector] private RectTransform dialogueTextRect;
 
     public ButtonSpawner buttonSpawner;
 
@@ -73,7 +75,9 @@ public class DialogueBoxController : MonoBehaviour
         {
             Debug.LogError("DialogueCanvas not found or does not have a Canvas component!");
         }
-
+        // Get the background transform for dimension changes
+        backgroundRect = _dialogueBox.transform.Find("BasicDialogueItems").transform.Find("Background").GetComponent<RectTransform>();
+        dialogueTextRect = _dialogueBox.transform.Find("BasicDialogueItems").transform.Find("DialogueText").GetComponent<RectTransform>();
     }
 
     public void updateAnimator() {
@@ -105,7 +109,12 @@ public class DialogueBoxController : MonoBehaviour
 
     IEnumerator RunDialogue(DialogueTree dialogueTree, int section)
     {
+        // Make the "Speak" restart tree the current tree
         dialogueTreeRestart = dialogueTree;
+        // Reset the dialogue box dimensions from "Speak" button dimensions
+        backgroundRect.sizeDelta = new Vector2(160,100);
+        dialogueTextRect.sizeDelta = new Vector2(150,60);
+
         for (int i = 0; i < dialogueTree.sections[section].dialogue.Length; i++) 
         {   
             // Start talking animation
@@ -192,10 +201,9 @@ public class DialogueBoxController : MonoBehaviour
     {
         ResetBox();
         _dialogueBox.SetActive(true);
-        //dialogueIsActive = true;
         _dialogueText.text = null;
-        RectTransform rt = _dialogueBox.transform.Find("BasicDialogueItems").transform.Find("Background").GetComponent<RectTransform>();
-        rt.sizeDelta = new Vector2(50,30);
+        backgroundRect.sizeDelta = new Vector2(50,30);
+        dialogueTextRect.sizeDelta = new Vector2(50,30);
         buttonSpawner.spawnSpeakButton(dialogueTree);
     }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When the speak button appears in dialogue, the dialogue text rectangle was the original size, making it so the "hitbox" of the dialogue canvas was bigger than the speak dialogue, so you would "hit" a transparent wall.

* **What is the new behavior?** (if this is a feature change)
The size is changed to the size required for the current dialogue (regular dialogue vs. speak button)

