### PR TITLE
Fix DiscarBox only respawning one knife

### DIFF
--- a/Assets/FishFactory/Scripts/Bleeding/DiscardKnife.cs
+++ b/Assets/FishFactory/Scripts/Bleeding/DiscardKnife.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 
 public class DiscardKnife : MonoBehaviour
@@ -26,7 +27,7 @@ public class DiscardKnife : MonoBehaviour
         {
             HandleAudioFeedback(Knife.GetComponent<KnifeState>());
             Destroy(Knife);
-            if (Knife.name == "BackupFishKnife")
+            if (Knife.name == "BackupFishKnife" || Knife.name == "FishKnife")
             {
                 Vector3 pos = new Vector3(4.56f,0.962f,-9.352f);
                 GameObject newKnife = Instantiate(_newKnifePrefab, pos, Quaternion.identity);


### PR DESCRIPTION
Refs:#669

<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Discard Box only respawns one knife
#669
* **What is the new behavior?** (if this is a feature change)
The Discard Box respawns both knifes

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

