### PR TITLE
Fix bug where when the knife was in holster and below y=0

### DIFF
--- a/Assets/FishFactory/Scripts/Bleeding/KnifeState.cs
+++ b/Assets/FishFactory/Scripts/Bleeding/KnifeState.cs
@@ -75,7 +75,7 @@ public class KnifeState : MonoBehaviour
 
     private void Update()
     {
-        if (transform.position.y <= 0)
+        if (transform.position.y <= 0 && transform.root == transform)
         {
             transform.position = new Vector3(4.56f, 0.962f, -9.352f);
         }


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The knife does no longer teleport when below y=0 and in your holster

* **What is the current behavior?** (You can also link to an open issue here)
the sprite teleports but the knife is still technically in the holster
#671

* **What is the new behavior?** (if this is a feature change)
The knife does not teleport if it is a child of something

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no