### PR TITLE
Dead fish task triggers consistently

### DIFF
--- a/Assets/FishMaintenance/Scenes/FishMaintenance.unity
+++ b/Assets/FishMaintenance/Scenes/FishMaintenance.unity
@@ -789,8 +789,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2.6233807, y: 3.2501292, z: 1.1596196}
-  m_Center: {x: 0.70199484, y: 1.1638548, z: 0.14230607}
+  m_Size: {x: 2.61, y: 191.27, z: 6.34}
+  m_Center: {x: -0.55, y: 1.23, z: 0.2}
 --- !u!4 &10405828
 Transform:
   m_ObjectHideFlags: 0
@@ -818,7 +818,7 @@ BoxCollider:
   m_GameObject: {fileID: 10405823}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Size: {x: 1.9305924, y: 2.9463913, z: 1.708485}
   m_Center: {x: -1.5102684, y: 0.84989727, z: -0.35424533}

--- a/Assets/FishMaintenance/Scripts/BreakTask.cs
+++ b/Assets/FishMaintenance/Scripts/BreakTask.cs
@@ -118,7 +118,7 @@ public class BreakTask : MonoBehaviour
             if (deadIntroDialoguePlayed && !deadIntroDone && breakTaskDone) // when the dead fish dialogue has finished
             {
                 Debug.Log(conversationController.GetDialogueTree().name);
-                if (!deadFishPumpVideo.activeSelf && conversationController.GetDialogueTree().name == "DeadfishSetup")
+                if (!deadFishPumpVideo.activeSelf && conversationController.GetDialogueTree().name == "DeadfishSetup") // activeSelf set to false when video is finished
                 {
                     // moving on to dead fish counting dialogue
                     conversationController.NextDialogueTree();


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
Previously when moving out of the collision box at the end of the break task dialog it deletes/disables the anchor making BreakTask.cs stop running, which makes it impossible to start the next dialogue. See #686.

* **What is the new behavior?** (if this is a feature change)
The handling of dead fish sub task triggers every time now, unless the walks around the fish cage and exits the now much larger collider which triggers the next dialogue. The fact that this box did not cover the entire maintenance boat made it easy for the player to break the logic which triggers the the sub task.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
None.
