### PR TITLE
Condition factor task no longer breaks when placing incorrect objects on scale

### DIFF
--- a/Assets/Laboratory/Scripts/NPCMicroscopeTask.cs
+++ b/Assets/Laboratory/Scripts/NPCMicroscopeTask.cs
@@ -196,6 +196,10 @@ public class NPCMicroscopeTask : MonoBehaviour
     /// <param name="answer"></param>
     private void ButtonSpawner_OnAnswer(string answer)
     {
+        // ensure that the correct dialogue tree is playing to prevent access of non-existent dialogues in if sentences
+        if (dialogueBoxController.dialogueTreeRestart.name != "LarsDialogue")
+            return;
+
         if (dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[20].branchPoint.question)
         {
             if (answer == "Yes")


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
The NPC breaks when the player places an incorrect object on the scale. #688

* **What is the new behavior?** (if this is a feature change)
The dialogue continues as expected now. The bug was fixed by checking in NPCMicroscopeTask.cs if the correct dialogue is playing before attempting to read the dialogue tree, thus preventing the script from trying to access out-of-bounds elements. This means that the bug was introduced with the plankton counting task.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it is a very minor change in the NPCMicroscopeTask.cs script.

* **Other information**:
None.