### PR TITLE
Make 360 videos rewatchabe. make next dialogue button interactable, and translate hints into English in the maintenance scenario.

### DIFF
--- a/Assets/FishMaintenance/HandFeeding/Scripts/HandFeeding.cs
+++ b/Assets/FishMaintenance/HandFeeding/Scripts/HandFeeding.cs
@@ -63,7 +63,7 @@ public class HandFeeding : MonoBehaviour
         {
 
             bucket.SetActive(false);
-            videoObject.SetActive(false);
+            videoObject.GetComponent<VideoObject>().HideVideoPlayer();
         }
     }
 

--- a/Assets/FishMaintenance/Scenes/FishMaintenance.unity
+++ b/Assets/FishMaintenance/Scenes/FishMaintenance.unity
@@ -7483,11 +7483,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
-      propertyPath: hideVideoPlayerAfterFirstWatch
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
       propertyPath: onPlay.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -7650,11 +7645,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
-      objectReference: {fileID: 0}
-    - target: {fileID: 5203972293542085776, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
-      propertyPath: m_Text
-      value: "Ber\xF8r for \xE5 spille av video"
       objectReference: {fileID: 0}
     - target: {fileID: 5203972293542085776, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
@@ -11913,6 +11903,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8751655888749084019, guid: 2ed7b7c5d7faa5b409bb115ae36faeef,
         type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8751655888749084019, guid: 2ed7b7c5d7faa5b409bb115ae36faeef,
+        type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -15711,11 +15706,6 @@ PrefabInstance:
       propertyPath: triggerSpecialEventOnVideoEnd
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
-      propertyPath: hideVideoPlayerAfterFirstWatch
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 907931764449879985, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
       propertyPath: m_Name
@@ -15811,11 +15801,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
-    - target: {fileID: 5203972293542085776, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
-      propertyPath: m_Text
-      value: "Ber\xF8r for \xE5 spille av video"
-      objectReference: {fileID: 0}
     - target: {fileID: 5203972293542085777, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
       propertyPath: m_LocalPosition.z
@@ -15884,6 +15869,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 8300000, guid: 9613dcbb58e447747a03e9b0e4ce7562,
             type: 3}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 812681642}
+        m_TargetAssemblyTypeName: VideoObject, Assembly-CSharp
+        m_MethodName: HideVideoPlayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
@@ -15975,7 +15972,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   onGrab:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 812681642}
+        m_TargetAssemblyTypeName: VideoObject, Assembly-CSharp
+        m_MethodName: HideVideoPlayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   onRelease:
     m_PersistentCalls:
       m_Calls:
@@ -16039,6 +16048,18 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &318205551 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 318205533}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318205535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 617e52c29d780a6439dbb86976e93ff0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &319390870
 GameObject:
   m_ObjectHideFlags: 0
@@ -18141,7 +18162,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 374839967}
-  m_LocalRotation: {x: -0, y: -0.86602545, z: -0, w: 0.49999994}
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -5.873, y: 0.060000002, z: 8.292}
   m_LocalScale: {x: 1.5, y: 1, z: 1.5}
   m_ConstrainProportionsScale: 0
@@ -18154,7 +18175,7 @@ Transform:
   - {fileID: 671109477}
   m_Father: {fileID: 2137830489}
   m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: -120, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!114 &374839969
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18275,8 +18296,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2.6747742, y: 4.336277, z: 1.8593111}
-  m_Center: {x: 0.43939307, y: 0.62078094, z: 0.38984254}
+  m_Size: {x: 0.8619584, y: 0.83583015, z: 0.8971461}
+  m_Center: {x: -0.014441569, y: 0.086916715, z: 0.05678308}
 --- !u!114 &374839974
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -39650,11 +39671,6 @@ PrefabInstance:
       propertyPath: triggerSpecialEventOnVideoEnd
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
-      propertyPath: hideVideoPlayerAfterFirstWatch
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 907931764449879985, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
       propertyPath: m_Name
@@ -39749,11 +39765,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
-      objectReference: {fileID: 0}
-    - target: {fileID: 5203972293542085776, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
-        type: 3}
-      propertyPath: m_Text
-      value: "Ber\xF8r for \xE5 spille av video"
       objectReference: {fileID: 0}
     - target: {fileID: 5203972293542085777, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
@@ -39915,6 +39926,18 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &812681642 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 907931764449879984, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 812681628}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812681630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 617e52c29d780a6439dbb86976e93ff0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &812827001
 GameObject:
   m_ObjectHideFlags: 0
@@ -71080,6 +71103,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+      - m_Target: {fileID: 318205551}
+        m_TargetAssemblyTypeName: VideoObject, Assembly-CSharp
+        m_MethodName: HideVideoPlayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!65 &1436856686
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -71091,8 +71126,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1.2288222, y: 4.336277, z: 1.2198322}
-  m_Center: {x: 0.16857171, y: 0.62078094, z: 0.29379222}
+  m_Size: {x: 1.2288221, y: 0.5500869, z: 1.2198322}
+  m_Center: {x: 0.16857171, y: 0.119579285, z: 0.2938012}
 --- !u!114 &1436856687
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/FishMaintenance/Scripts/BreakTask.cs
+++ b/Assets/FishMaintenance/Scripts/BreakTask.cs
@@ -14,17 +14,12 @@ public class BreakTask : MonoBehaviour
 
     [SerializeField] private GameObject deadFishBreakAnchor;
 
-    
-
-    private int _activatedCount = 0;
-    private Task.Step breakStep;
     private DialogueBoxController dialogueController;
     private ConversationController conversationController;
 
     private bool breakDialoguePlayed = false;
     private bool breakTaskDone = false;
     private bool deadIntroDialoguePlayed = false;
-    private bool deadIntroDone = false;
 
 
 
@@ -41,50 +36,6 @@ public class BreakTask : MonoBehaviour
         dialogueController = _npc.GetComponent<DialogueBoxController>();
         conversationController = _npc.GetComponentInChildren<ConversationController>();
     }
-
-    // Update is called once per frame
-    /*    void Update()
-        {
-            Task.Task task = mm.MaintenanceTask;
-            Task.Step breakStep = mm.GetStep("Pause", "Talk to Laila");
-            ConversationController conversationController = _npc.GetComponentInChildren<ConversationController>();
-            //Debug.Log(conversationController.isDialogueActive());
-            //Debug.Log(dialogueController.dialogueEnded);
-            if (task.GetSubtask("Hand-feeding").Compleated() && task.GetSubtask("Daily Round").Compleated() && !conversationController.isDialogueActive())
-            {
-                if (conversationController == null)
-                {
-                    Debug.LogError("The NPC is missing the conversationController");
-                }
-                if (dialogueController.dialogueEnded && !breakStep.IsCompeleted() && dialogueController.timesEnded == 1)
-                {
-                    mm.CompleteStep(breakStep);
-                    deadfishTask.SetActive(true);
-                    breakAnchor.SetActive(false);
-                    conversationController.SetDialogueTreeList(new List<DialogueTree>
-                    {
-                        null
-                    });
-                    this.enabled = false;
-                    return;
-                }
-                else
-                {
-                    conversationController.SetDialogueTreeList(dialogueTree);
-                }
-            }
-            if (_activatedCount == 3)
-            {
-                mm.BadgeChanged.Invoke(skillBadge);
-            }
-            else
-            {
-                int updatedCount = conversationController.GetActivatedCount();
-                if (_activatedCount < 4) _activatedCount = updatedCount;
-
-            }
-
-        }*/
 
     private void Update()
     {
@@ -103,50 +54,31 @@ public class BreakTask : MonoBehaviour
                     conversationController.DialogueTrigger();
                     deadIntroDialoguePlayed = true;
                     deadFishPumpVideo.SetActive(true);
-
-                    //mm.PlayAudio(mm.success);
-                    //mm.InvokeBadge(mm.taskHolder.GetSkill("Observant"));
                 }
-
-
-
-                //breakAnchor.SetActive(false);
-                //gameObject.SetActive(false);
                 breakTaskDone = true;
             }
 
-            if (deadIntroDialoguePlayed && !deadIntroDone && breakTaskDone) // when the dead fish dialogue has finished
+            if (deadIntroDialoguePlayed && breakTaskDone) // when the dead fish dialogue has finished
             {
-                Debug.Log(conversationController.GetDialogueTree().name);
-                if (!deadFishPumpVideo.activeSelf && conversationController.GetDialogueTree().name == "DeadfishSetup") // activeSelf set to false when video is finished
+                if (conversationController.GetDialogueTree().name != "DeadfishSetup")
+                    return;
+
+                //Debug.Log(conversationController.GetDialogueTree().name);
+                if (mm.GetStep("Handling of dead fish", "Watch video").RepetionsCompleated >= 1 && conversationController.GetDialogueTree().name == "DeadfishSetup") // activeSelf set to false when video is finished
                 {
                     // moving on to dead fish counting dialogue
                     conversationController.NextDialogueTree();
                     conversationController.DialogueTrigger();
+                    deadFishPumpVideo.GetComponent<VideoObject>().HideVideoPlayer();
                     deadFishCountVideo.SetActive(true);
                     deadFishBreakAnchor.SetActive(true);
 
                     mm.taskHolder.GetTask("Maintenance").GetSubtask("Handling of dead fish").GetStep("Get info from Laila").SetCompleated(true);
                     mm.PlayAudio(mm.success);
                     mm.InvokeBadge(skillBadge);
-
-                    deadIntroDone = true;
                 }
             }
         }
-
-/*        if (mm.taskHolder.GetTask("Maintenance").GetSubtask("Handling of dead fish").GetStep("Push the dead fish into the tub").IsCompeleted())
-            Debug.Log("Completed");
-
-        if (mm.taskHolder.GetTask("Maintenance").GetSubtask("Handling of dead fish").Compleated())
-        {
-            Debug.Log("Completed");
-            if (conversationController.GetDialogueTree().name == "DeadfishExplanation")
-            {
-                conversationController.NextDialogueTree();
-                conversationController.DialogueTrigger();
-            }
-        }*/
     }
 
     private void OnTriggerEnter(Collider other)

--- a/Assets/VR4VET/Components/360VideoPlayer/Scripts/VideoObject.cs
+++ b/Assets/VR4VET/Components/360VideoPlayer/Scripts/VideoObject.cs
@@ -99,8 +99,7 @@ public class VideoObject : MonoBehaviour
 
         if (hideVideoPlayerAfterFirstWatch && VideoIsPlayedOnce)
         {
-            hintText.text = null;
-            gameObject.SetActive(false);
+            HideVideoPlayer();
         }
 
     }
@@ -145,6 +144,19 @@ public class VideoObject : MonoBehaviour
         transform.localScale = new Vector3(0.7f, 0.7f, 0.7f);
 
     }
+
+    public void HideVideoPlayer()
+    {
+        hintText.text = null;
+        gameObject.SetActive(false);
+    }
+
+    public void ShowVideoPlayer()
+    {
+        hintText.text = hintText.text = "Grab To Play"; ;
+        gameObject.SetActive(true);
+    }
+
 
 
 }


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** 
Feature, fix, and improvements

* **What is the current behavior?**
The 360 video headset model disappears immediately when released, making it easy to miss the video as they are not rewatchable (#715). 
  
  The floating hints above the model is currently written in Norwegian (#726).
  
  The colliders used for the different stations sometimes cover the NPC's dialogue box, making it impossible to click the next-button (#727).

* **What is the new behavior?** 
The 360 video headsets now only disappear when the player progresses. The first headset at the hand-feeding station disappears when exiting its area. The second headset showcasing how dead fish are pumped out of the cage disappears when watching the next video (pushing dead fish into the tub). The last headset (pushing dead fish into the tub) disappears when entering the dead fish station.

  The floating hints are now in English.

  The colliders are much smaller now, just large enough to snap the teleport marker into place without blocking the NPC's dialogue box.

* **Does this PR introduce a breaking change?**
No.

* **Other information**:
None.