### PR TITLE
Bleeding station, QA station, and laboratory NPCs update

### DIFF
--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationDialogue.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationDialogue.asset
@@ -16,11 +16,14 @@ MonoBehaviour:
   speakButtonOnExit: 1
   sections:
   - dialogue:
-    - Hello. My name is Bent and welcome to the Bleeding Station!
-    - Your task here is to euthanize fish in a humane way.
+    - Hello. My name is Bernard and welcome to the Bleeding Station!
+    - Your task here is to manually process the fish which have not gone through
+      the automatic bleeding machine.
     - "This is done by cutting the gills of stunned fish.\r"
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Are you ready to learn more?
       answers:
@@ -38,6 +41,8 @@ MonoBehaviour:
       working.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Have you completed this course?
       answers:
@@ -51,6 +56,8 @@ MonoBehaviour:
     - Great! You should know that fish should not be alive for more than 15 seconds.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Let's continue.
       answers:
@@ -64,9 +71,14 @@ MonoBehaviour:
       according to Tesco\u2019s requirements for fish welfare.\r"
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
-      question: 
-      answers: []
+      question: It is important to not cause unnecessary distress for the fish!
+      answers:
+      - answerLabel: Understood, sir!
+        nextElement: 4
+        endAfterAnswer: 0
   - dialogue:
     - "You will find a knife in your right pocket. When the knife is not in use it
       should be placed in your pocket.\r"
@@ -80,6 +92,8 @@ MonoBehaviour:
       beside it.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Did you understand everything?
       answers:
@@ -101,6 +115,8 @@ MonoBehaviour:
       belt. Such inedible fish should be thrown in the basket next to the stun machine.\r"
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Is that clear?
       answers:
@@ -115,6 +131,8 @@ MonoBehaviour:
     - All fish must be cut before they move to the next station!
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Is there anything else you wish to know?
       answers:

--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationDialogue.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationDialogue.asset
@@ -53,7 +53,8 @@ MonoBehaviour:
         nextElement: 2
         endAfterAnswer: 0
   - dialogue:
-    - Great! You should know that fish should not be alive for more than 15 seconds.
+    - Great! You should know that conscious fish must not be left out of water for
+      longer than 15 seconds or left in the stunning machine.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
     point: 0
@@ -67,8 +68,8 @@ MonoBehaviour:
   - dialogue:
     - If you have not completed the fish welfare course you need to work under supervision
       for up to a year.
-    - "It is important that the fish are not alive longer than 15 seconds after stunning
-      according to Tesco\u2019s requirements for fish welfare.\r"
+    - Conscious fish must not be left out of water for longer than 15 seconds or
+      left in the stunning machine.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
     point: 0
@@ -76,7 +77,7 @@ MonoBehaviour:
     branchPoint:
       question: It is important to not cause unnecessary distress for the fish!
       answers:
-      - answerLabel: Understood, sir!
+      - answerLabel: Understood!
         nextElement: 4
         endAfterAnswer: 0
   - dialogue:

--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationGuide.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/BleedingStationGuide.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 08df34276ae9b5f4fbdd63d5671e73fe, type: 3}
   m_Name: BleedingStationGuide
   m_EditorClassIdentifier: 
-  NameOfNPC: Bleeding station guide Bent
+  NameOfNPC: Bleeding station guide Bernard
   NpcPrefab: {fileID: 142329030213301039, guid: ff4da975a925d9447a923de91bf35e65,
     type: 3}
   CharacterModel: {fileID: 919132149155446097, guid: 09f468ac47f01b548ac3b433bcabac15,

--- a/Assets/FishFactory/Resources/Prefabs/NPC/QAStation/QADialogue.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/QAStation/QADialogue.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
       out. Please step on the platform next to me to use the sorting machine.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Are you ready to learn how to use the sorting machine?
       answers:
@@ -40,6 +42,8 @@ MonoBehaviour:
       used to sort the fish.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Are you ready to learn how to use the buttons?
       answers:
@@ -58,6 +62,8 @@ MonoBehaviour:
       you only need to worry about the tree buttons closest to you.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Are you ready to learn more?
       answers:
@@ -80,6 +86,8 @@ MonoBehaviour:
       button to change the active tier.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Have you understood how the machine works?
       answers:
@@ -87,7 +95,7 @@ MonoBehaviour:
         nextElement: 2
         endAfterAnswer: 0
       - answerLabel: Could you explain how the machine works again?
-        nextElement: 1
+        nextElement: 5
         endAfterAnswer: 0
       - answerLabel: Yes!
         nextElement: 4
@@ -101,9 +109,47 @@ MonoBehaviour:
       He is waiting over by the gutting machine.
     endAfterDialogue: 1
     disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
     branchPoint:
       question: Good luck!
       answers:
       - answerLabel: Could you repeat that?
         nextElement: 0
+        endAfterAnswer: 0
+  - dialogue:
+    - The sorting machine is made up of a button panel with 6 buttons on the front
+      and a button on the side. Apart from the button panel there are four slots
+      where the fish can be placed.
+    endAfterDialogue: 0
+    disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
+    branchPoint:
+      question: Which slot you place the fish in does not matter. You can use whatever
+        slot is available regardless of the quality of the fish. It's the buttons
+        that are used to sort the fish.
+      answers:
+      - answerLabel: Could you repeat that?
+        nextElement: 5
+        endAfterAnswer: 0
+      - answerLabel: Got it!
+        nextElement: 6
+        endAfterAnswer: 0
+  - dialogue: []
+    endAfterDialogue: 0
+    disabkeSkipLineButton: 0
+    point: 0
+    objectToLookAt: {fileID: 0}
+    branchPoint:
+      question: Have you understood how the machine works?
+      answers:
+      - answerLabel: No, could you explain the buttons again?
+        nextElement: 2
+        endAfterAnswer: 0
+      - answerLabel: Could you explain how the machine works again?
+        nextElement: 5
+        endAfterAnswer: 0
+      - answerLabel: Yes!
+        nextElement: 4
         endAfterAnswer: 0

--- a/Assets/FishFactory/ScriptableObjects/Steps/Bleeding/TalkToNpc.asset
+++ b/Assets/FishFactory/ScriptableObjects/Steps/Bleeding/TalkToNpc.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dba923aa6c2abb445a10c35f5df190aa, type: 3}
   m_Name: TalkToNpc
   m_EditorClassIdentifier: 
-  _stepName: Talk to bent
+  _stepName: Talk to Bernard
   _repetionNumber: 1
   _timer: -1

--- a/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
+++ b/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
@@ -19,8 +19,8 @@ MonoBehaviour:
     - Now you are going to analyse a water sample in the microscope. Your goal is
       to look after different organisms in the sample, and count how many there are.
     - The sample is simplified for learning purposes. The slide only has 50 squares,
-      and there's less than 50 plankton of each type. A typical slide could have
-      1000 squares and a much higher plankton count.
+      and there's less than 50 plankton of each type. A typical slide can have 1000
+      squares and a much higher plankton count.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
     point: 0

--- a/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
+++ b/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
@@ -16,8 +16,11 @@ MonoBehaviour:
   speakButtonOnExit: 1
   sections:
   - dialogue:
-    - Now you are going to analyze a water sample in the microscope. Your goal is
+    - Now you are going to analyse a water sample in the microscope. Your goal is
       to look after different organisms in the sample, and count how many there are.
+    - The sample is simplified for learning purposes. The slide only has 50 squares,
+      and there's less than 50 plankton of each type. A typical slide could include
+      1000 squares and a much higher plankton count.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
     point: 0
@@ -35,10 +38,9 @@ MonoBehaviour:
   - dialogue:
     - First place the water sample under the scope, this is the blue rectangle to
       the right of the microscope.
-    - Now you can see the sample on the screen, press one of the big arrows to move
+    - Now you can see the sample on the screen. Press one of the big arrows to move
       around.
-    - Try to change the speed of how fast you move around by pressing plus or
-      minus.
+    - Try to change the speed of how fast you move around by pressing plus or minus.
     - Zoom in or out by scrolling the nosepieces over the sample
     - On the left side of the microscope there is a counter. Grab it with your left
       hand and press the button on your index finger to count.
@@ -127,7 +129,8 @@ MonoBehaviour:
         nextElement: 7
         endAfterAnswer: 0
   - dialogue:
-    - There are 100 Chaetoceros diatom, 350 Pseudo-nitzschia, and 150 Skeletonema.
+    - I counted 13 Chaetoceros diatom, 48 Pseudo-nitzschia diatom, and 38 Skeletonema
+      diatom.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0
     point: 0

--- a/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
+++ b/Assets/Laboratory/Prefabs/NPC/DialogueTrees/MicroscopeDialogue.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     - Now you are going to analyse a water sample in the microscope. Your goal is
       to look after different organisms in the sample, and count how many there are.
     - The sample is simplified for learning purposes. The slide only has 50 squares,
-      and there's less than 50 plankton of each type. A typical slide could include
+      and there's less than 50 plankton of each type. A typical slide could have
       1000 squares and a much higher plankton count.
     endAfterDialogue: 0
     disabkeSkipLineButton: 0


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?**
Bug fix, improvements/enhancements

* **What is the current behavior?**
  - The NPC in the bleeding station is called 'Bent', which is weird in English (#721)
  - He is incorrect when he claims fish should not be alive for more than 15 seconds, and he doesn't mention that the manual bleeding process only applies to fish that doesn't go through the automatic bleeding machine (#720)
  - His dialogue also breaks and a blank canvas is shown when clicking the arrow button to proceed past the section about TESCO's welfare standards (#729)
  - The laboratory NPC does not mention that the plankton counting task is simplified/simulated (#713)
  - The quality assurance NPC's responses overlap when asked to repeat how the buttons or the machine work (#730)


* **What is the new behavior?**
  - The bleeding station NPC is now called 'Bernard'.
  - He no longer talks about fish being alive for more than 15 seconds, but instead that fish should not be left out of water for more than 15 seconds, and that they should not be left in the stunning machine. He also mentions that the task is to manually process the fish which have not gone through the automatic bleeding machine, hopefully making it clear that most fish are not processed manually like that.
  - The dialogue no longer breaks when progressing past this point.
  - The laboratory NPC now mentions that the sample is simplified, having 50 squares and less than 50 plankton of each type. He also informs the player that a typical microscope slide can have 1000 squares and a higher plankton count.
  - The quality assurance NPC's responses are now separated into different sections, removing most of the overlap.



* **Does this PR introduce a breaking change?**
No.


* **Other information**:
None.