### PR TITLE
Walking npc improvements

### DIFF
--- a/Assets/FishFeeding/Scripts/SpecializedNPCBehavior.cs
+++ b/Assets/FishFeeding/Scripts/SpecializedNPCBehavior.cs
@@ -149,7 +149,7 @@ public class SpecializedNPCBehavior : MonoBehaviour
             Quaternion rotation = Quaternion.LookRotation(lookPos);
             _npc.transform.rotation = Quaternion.Slerp(_npc.transform.rotation, rotation, 0.04f);
 
-            float rotationOffset = Vector3.Angle((lookPos - _npc.transform.position), _npc.transform.forward);
+            float rotationOffset = Vector3.Angle((new Vector3(destination.x, _npc.transform.position.y, destination.z) - _npc.transform.position), _npc.transform.forward);
 
             if (rotationOffset < 0.01f) 
                 rotating = false;

--- a/Assets/Laboratory/Scenes/Laboratory.unity
+++ b/Assets/Laboratory/Scenes/Laboratory.unity
@@ -2670,6 +2670,36 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 13.186775
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 6.73359
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 12.506645
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.7243357
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 3.3644614
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035982357732536810, guid: 99af574f509ad8e44b94f3fe4a620d2c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.39371014
+      objectReference: {fileID: 0}
     - target: {fileID: 6446317599382693953, guid: 99af574f509ad8e44b94f3fe4a620d2c,
         type: 3}
       propertyPath: m_StaticEditorFlags
@@ -8253,7 +8283,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 172813501}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6.902, y: 9.27782, z: -13.745}
+  m_LocalPosition: {x: -7.135, y: 9.27782, z: -14.045}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -19139,6 +19169,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2020230914}
+  - {fileID: 610148319}
   m_Father: {fileID: 1489868298}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -19489,6 +19520,37 @@ Transform:
   - {fileID: 2042007483}
   m_Father: {fileID: 557122229}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &360239844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 360239845}
+  m_Layer: 0
+  m_Name: Point (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &360239845
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360239844}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.298, y: 9.27782, z: -12.7135}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1224292052}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &361437635
 GameObject:
@@ -32339,6 +32401,37 @@ Transform:
   - {fileID: 1206427928}
   m_Father: {fileID: 1535333540}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &610148318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 610148319}
+  m_Layer: 0
+  m_Name: Point (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &610148319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 610148318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.906, y: 1.269, z: -7.448}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 355366326}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &611214910
 GameObject:
@@ -63851,6 +63944,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 172813502}
+  - {fileID: 360239845}
   m_Father: {fileID: 1844035021}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -104713,7 +104807,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2020230913}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.845, y: 1.269, z: -5.701}
+  m_LocalPosition: {x: -1.618, y: 1.269, z: -6.297}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Laboratory/Scripts/WalkingNpc.cs
+++ b/Assets/Laboratory/Scripts/WalkingNpc.cs
@@ -25,7 +25,6 @@ public class WalkingNpc : MonoBehaviour
     private bool rotating;
     private GameObject _npcFeedback;
 
-
     // Start is called before the first frame update
     void Start()
     {
@@ -131,9 +130,10 @@ public class WalkingNpc : MonoBehaviour
                     NavMeshPath path = new NavMeshPath();
                     _agent.CalculatePath(paths[currentPath][currentPosition].position, path);
                     _agent.SetPath(path);
-                    if (_agent.remainingDistance > 0.1f)
+                    if (_agent.remainingDistance < 1.8f)
                     {
                         currentPosition++;
+                        currentPosition = 2;
                         if (currentPosition == paths[currentPath].Count)
                         {
                             rotating = true;
@@ -157,9 +157,11 @@ public class WalkingNpc : MonoBehaviour
                     NavMeshPath path = new NavMeshPath();
                     _agent.CalculatePath(paths2[currentPath][currentPosition].position, path);
                     _agent.SetPath(path);
-                    if (_agent.remainingDistance > 0.1f)
+                    if (_agent.remainingDistance < 0.9f)
                     {
                         currentPosition++;
+                        currentPosition = 2;
+                        
                         if (currentPosition == paths2[currentPath].Count)
                         {
                             rotating = true;

--- a/Assets/Laboratory/Scripts/WalkingNpc.cs
+++ b/Assets/Laboratory/Scripts/WalkingNpc.cs
@@ -197,7 +197,7 @@ public class WalkingNpc : MonoBehaviour
                 Quaternion rotation = Quaternion.LookRotation(lookPos);
                 _npc.transform.rotation = Quaternion.Slerp(_npc.transform.rotation, rotation, 0.04f);
 
-                float rotationOffset = Vector3.Angle((lookPos - _npc.transform.position), _npc.transform.forward);
+                float rotationOffset = Vector3.Angle((new Vector3(destination.x, _npc.transform.position.y, destination.z) - _npc.transform.position), _npc.transform.forward);
 
                 if (rotationOffset < 0.01f) 
                     rotating = false;  
@@ -211,7 +211,7 @@ public class WalkingNpc : MonoBehaviour
                 Quaternion rotation = Quaternion.LookRotation(lookPos);
                 _npc.transform.rotation = Quaternion.Slerp(_npc.transform.rotation, rotation, 0.04f);
 
-                float rotationOffset = Vector3.Angle((lookPos - _npc.transform.position), _npc.transform.forward);
+                float rotationOffset = Vector3.Angle((new Vector3(destination.x, _npc.transform.position.y, destination.z) - _npc.transform.position), _npc.transform.forward);
 
                 if (rotationOffset < 0.01f) 
                     rotating = false;    


### PR DESCRIPTION
# What kind of change does this PR introduce?
improvements and fixes

# What is the current behavior?

* The player is able to teleport on the lab roof

* The NPC is unable to rotate after walking to a location in the lab making it more difficult to place the npc in a good location and casuing inconvience for the player (#703)

* The dialogue box doesn't rotate when the npc rotatets which can cause inconvient situations (#697)


# What is the new behavior?

* The box collider for the roof has been increased so the player is unable to teleport on the roof

* The WalkingNPC script now works as intented and now it will turn after walking. The paths have also been adjusted so the NPC stands in a better location

* When the npc rotatets the dialogue box will rotate with it so they always face in the same direction


# Other information

There are still many issues with the walking npc script both in the Lab and Fish Feeding that I tried to solve but couldn't find a solution for. The best thing to do is probably to rework the entire feature, as of now the script is easy to break and is difficult to implement in multiple scenarios. (#732)

