### PR TITLE
Create unity event for dialogue change

### DIFF
--- a/Assets/Laboratory/Prefabs/NPC/LabratoryLars.asset
+++ b/Assets/Laboratory/Prefabs/NPC/LabratoryLars.asset
@@ -26,6 +26,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: d05353bc3b47f0a4b9a8716ba64eaa3b, type: 2}
   - {fileID: 11400000, guid: 4a0bb79cf1ecd8244a116d718cd21e8a, type: 2}
   - {fileID: 11400000, guid: 2999499e18d39d748a4dc217aa06a6b7, type: 2}
+  - {fileID: 11400000, guid: dd2180fe7d7193a41aa8d8d40a360815, type: 2}
+  - {fileID: 11400000, guid: 6a238f60b92f88348ac5531ebf3ee66a, type: 2}
+  - {fileID: 11400000, guid: ca064b28720a1af41931ed80b9733d7c, type: 2}
   DialogueTreeJSON: []
   runtimeAnimatorController: {fileID: 9100000, guid: acb4b9981fa45ce46adb4867634b31ab,
     type: 2}

--- a/Assets/Laboratory/Scripts/NPCMicroscopeTask.cs
+++ b/Assets/Laboratory/Scripts/NPCMicroscopeTask.cs
@@ -34,9 +34,6 @@ public class NPCMicroscopeTask : MonoBehaviour
     private float startTime = 0;
     private void Update()
     {
-        /*if (dialogueBoxController.dialogueTreeRestart.name != "Introduction" || (dialogueBoxController.dialogueTreeRestart.name != "MicroscopeDialogue"))
-            return;*/
-
         if (dialogueBoxController.dialogueTreeRestart == null)
             return;
 
@@ -89,7 +86,7 @@ public class NPCMicroscopeTask : MonoBehaviour
                 // checking if player has placed slide onto microscope
                 if (slide == null)
                 {
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 8, "MicroscopeDialogue");
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 8, "MicroscopeDialogue", 0);
                     return;
                 }
 
@@ -102,7 +99,7 @@ public class NPCMicroscopeTask : MonoBehaviour
                 }
                 
                 if (correct)
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 5, "MicroscopeDialogue");
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 5, "MicroscopeDialogue", 0);
                 else
                 {
                     // dynamically adding dialogue with correct answers. this could be a risky operation!
@@ -111,7 +108,7 @@ public class NPCMicroscopeTask : MonoBehaviour
                         $"{slide.GetTotalAmountOfPseudoNitzschia()} Pseudo-nitzschia diatom, " +
                         $"and {slide.GetTotalAmountOfSkeletonema()} Skeletonema diatom.";
 
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 6, "MicroscopeDialogue");    
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 6, "MicroscopeDialogue", 0);    
                 }
             }
             return;
@@ -130,7 +127,7 @@ public class NPCMicroscopeTask : MonoBehaviour
                 // checking if player has placed slide onto microscope
                 if (slide == null)
                 {
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 8, "MicroscopeDialogue");
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 8, "MicroscopeDialogue", 0);
                     return;
                 }
 
@@ -138,12 +135,12 @@ public class NPCMicroscopeTask : MonoBehaviour
                 if (HighLightPlankton)
                 {
                     EnablePlanktonHighlights.Invoke();
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 11, "MicroscopeDialogue");
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 11, "MicroscopeDialogue", 0);
                 }     
                 else
                 {
                     DisablePlanktonHighlights.Invoke();
-                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 12, "MicroscopeDialogue");
+                    dialogueBoxController.StartDialogue(dialogueBoxController.dialogueTreeRestart, 12, "MicroscopeDialogue", 0);
                 }   
             }
         }

--- a/Assets/Laboratory/Scripts/NpcTriggerDialogue.cs
+++ b/Assets/Laboratory/Scripts/NpcTriggerDialogue.cs
@@ -9,14 +9,6 @@ public class NpcTriggerDialogue : MonoBehaviour
    // ----------------- Editor Variables -----------------
    [SerializeField]   
    public UnityEvent triggerEvent;
-   [FormerlySerializedAs("dialogueTree")] [SerializeField]     
-   public DialogueTree feedbackDialogueTree;
-   [SerializeField]
-   public DialogueTree larsDialogueTree;
-   [SerializeField] 
-   public DialogueTree introDialogueTree;
-   [SerializeField]
-   public DialogueTree errorFeedbackDialogueTree;
    [SerializeField]  
    public string npcName;
 
@@ -38,14 +30,20 @@ public class NpcTriggerDialogue : MonoBehaviour
    private Quaternion _fishRotation;
   
 
-   private DialogueBoxController dialogueBoxController;
-   private int _dialogueIndex;
-   public string currentDialogue;
+   private DialogueBoxController _dialogueBoxController;
+   private ConversationController _conversationController;
+   
+   // These variables are used to keep track of the current and previous dialogue
+   private string _currentDialogue = "", _oldDialogue = "";
+   private int _oldSection, _oldIndex, _currentSection, _currentIndex = 0;
+   
+   
 
    private void Start()
    {
-       dialogueBoxController = FindObjectOfType<DialogueBoxController>();
-       //_walkingNpc = FindObjectOfType<WalkingNpc>();
+       _dialogueBoxController = FindObjectOfType<DialogueBoxController>();
+       _conversationController = FindObjectOfType<ConversationController>();
+
        // Save the initial positions of the objects
        _basketPosition = basket.transform.position;
        _basketRotation = basket.transform.rotation;
@@ -53,95 +51,49 @@ public class NpcTriggerDialogue : MonoBehaviour
        _handheldCounterRotation = handheldCounter.transform.rotation;
        _fishPosition = fish.transform.position;
        _fishRotation = fish.transform.rotation;
-   }  
-   
-   private void Update()
-   {
-       // Checks if the dialogue is supposed to return to the Lars Dialouge tree and call the ChangeToLars method
-       if (dialogueBoxController.dialogueTreeRestart != null)
-       {
-           if ((dialogueBoxController.dialogueTreeRestart.name == "NpcFeedback" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[6].dialogue[0]) 
-               || (dialogueBoxController.dialogueTreeRestart.name == "ErrorFeedback" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[0]))
-           {
-               ResetDialogue(dialogueBoxController.dialogueTreeRestart.name);
-           
-           }
-           else if (dialogueBoxController.dialogueTreeRestart.name == "Introduction" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[3].dialogue[0] || dialogueBoxController.dialogueTreeRestart.name == "Introduction" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
-           {
-               currentDialogue = dialogueBoxController._dialogueText.text;
-           }
-           else if (dialogueBoxController.dialogueTreeRestart.name == "MicroscopeDialogue" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[2].dialogue[0])
-           {
-               ResetDialogue(dialogueBoxController.dialogueTreeRestart.name);
-           }
-       }
-
-   }
+       _dialogueBoxController.m_DialogueChanged.AddListener(OnDialogueChanged);
+   } 
    
    private void OnTriggerEnter(Collider other)
    {
       triggerEvent.Invoke();
    }
-
-   // Find the index of the current dialogue section
-   public void FindDialogueSection()
-   {
-       // Only stores the dialogue section index if the dialogue is LarsDialogue
-       if (dialogueBoxController.dialogueTreeRestart.name != "LarsDialogue")
-       {
-           return;
-       }
-       else
-       {
-           for (int i = 0; i < dialogueBoxController.dialogueTreeRestart.sections.Length; i++)
-           {
-               for (int j = 0; j < dialogueBoxController.dialogueTreeRestart.sections[i].dialogue.Length; j++)
-               {
-                   if (dialogueBoxController.dialogueTreeRestart.sections[i].dialogue[j] == dialogueBoxController._dialogueText.text)
-                   {
-                       _dialogueIndex = i;
-                       break;
-                   }
-               }
-           }
-       }
-   }
    
    // Everything correct
    public void response1() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 0, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 0, npcName, 0);
    }
 // Forgot basket
    public void response2() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 1, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 1, npcName, 0);
    }
 // Wrong condition factor
    public void response3() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 2, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 2, npcName, 0);
    }
 // Wrong length
    public void response4() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 3, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 3, npcName, 0);
    }
 // Wrong weight
    public void response5() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 4, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 4, npcName, 0);
    }
 // Everything is wrong
    public void response6() {
-         dialogueBoxController.StartDialogue(feedbackDialogueTree, 5, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("NpcFeedback"), 5, npcName, 0);
    }
    
    // When the player places a object on the weight scale before turning it on
    public void Error1() {
          
-         dialogueBoxController.StartDialogue(errorFeedbackDialogueTree, 0, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("ErrorFeedback"), 0, npcName, 0);
          
    }
    
    // When the player places the wrong object on the weight scale
    public void Error2() {
-         dialogueBoxController.StartDialogue(errorFeedbackDialogueTree, 2, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("ErrorFeedback"), 2, npcName, 0);
    }
    
    // When the player places the fish without using the basket
@@ -153,7 +105,7 @@ public class NpcTriggerDialogue : MonoBehaviour
              Destroy(instance);
          }
          Instantiate(fishPrefab, _fishPosition, _fishRotation);
-         dialogueBoxController.StartDialogue(errorFeedbackDialogueTree, 3, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("ErrorFeedback"), 3, npcName, 0);
    }
    
    // When the player places the fish before turning on the weight
@@ -164,12 +116,12 @@ public class NpcTriggerDialogue : MonoBehaviour
            Destroy(instance);
        }
        Instantiate(fishPrefab, _fishPosition, _fishRotation);
-       dialogueBoxController.StartDialogue(errorFeedbackDialogueTree, 0, npcName);
+       _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("ErrorFeedback"), 0, npcName, 0);
    }
    
    // When the player places something that is not a fish on the number keypad
    public void Error5() {
-         dialogueBoxController.StartDialogue(errorFeedbackDialogueTree, 4, npcName);
+         _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("ErrorFeedback"), 4, npcName, 0);
    }
 
    private void ResetDialogue(string dialogueName)
@@ -177,7 +129,7 @@ public class NpcTriggerDialogue : MonoBehaviour
        // Runs when the player has completed calculating the condition factor and resets everything in the scene.
        if (dialogueName == "NpcFeedback")
        {
-           dialogueBoxController.StartDialogue(introDialogueTree, 2, npcName);
+           _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("Introduction"), 2, npcName, 0);
        
            basket.transform.position = _basketPosition;
            basket.transform.rotation = _basketRotation;
@@ -206,13 +158,88 @@ public class NpcTriggerDialogue : MonoBehaviour
        // Runs when the player has made a mistake and returns the dialogue to the same section the player was in when they made the mistake.
        else if (dialogueName == "ErrorFeedback")
        {
-           dialogueBoxController.StartDialogue(larsDialogueTree, _dialogueIndex, npcName);
+           _dialogueBoxController.StartDialogue(GetDialogueTreeFromName(_returnDialogue), _returnSection, npcName, _returnIndex);
        }
        
        else if (dialogueName == "MicroscopeDialogue")
        {
-           dialogueBoxController.StartDialogue(introDialogueTree, 2, npcName);
+           _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("Introduction"), 2, npcName, 0);
        }
+   }
+   
+   // Variables to store the dialogue the player was in before the mistake was made.
+   private string _returnDialogue = "";
+   private int _returnSection = 0; 
+   private int _returnIndex = 0;
+   
+   /// <summary>
+   /// This method is called when the dialogue changes. It saves the current dialogue and the previous dialogue. When the dialogue changes to ErrorFeeback it will save the previous dialogue so it can return to it.
+   /// It will also call the ResetDialogue method when the player is ready to return to the task.
+   /// </summary>
+   private void OnDialogueChanged(string npcName, string dialogueTree, int section, int index)
+   {
+       // The variables for the old dialogue are set before the new dialogue is set, making it represent the previous duologue.
+       _oldDialogue = _currentDialogue;
+       _oldSection = _currentSection;
+       _oldIndex = _currentIndex;
+       // The variables store information about the current dialogue.
+       _currentDialogue = dialogueTree;
+       _currentSection = section;
+       _currentIndex = index;
+        
+       // The old dialogue is saved when the dialogue tree changes to ErrorFeedback from LarsDialogue or MicroscopeDialogue, which will be used to return to the dialogue the player was in before the mistake was made.
+       if ((_oldDialogue.Equals("LarsDialogue") || _oldDialogue.Equals("MicroscopeDialogue")) && _currentDialogue.Equals("ErrorFeedback"))
+       {
+           _returnDialogue = _oldDialogue;
+           _returnSection = _oldSection;
+           _returnIndex = _oldIndex;
+       }
+       
+       // The ResetDialogue method after the player has received feedback and is ready to return to the original dialogue.
+       if ((dialogueTree == "NpcFeedback" && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[6].dialogue[0]) 
+           || (dialogueTree == "ErrorFeedback" && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[0]))
+       {
+           ResetDialogue(dialogueTree);
+       }
+       else if (dialogueTree == "MicroscopeDialogue" && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[2].dialogue[0])
+       {
+           ResetDialogue(dialogueTree);
+       } 
+   }
+
+   /// <summary>
+   /// This method finds the previous dialogue and returns to it.
+   /// </summary>
+   private void GoToPreviousDialogue()
+   {
+       DialogueTree previousDialogueTree = null;
+
+       foreach (DialogueTree tree in _conversationController.GetDialogueTrees())
+       {
+           if (tree.name.Equals(_oldDialogue))
+               previousDialogueTree = tree;
+       }
+
+       if (previousDialogueTree != null)
+            _dialogueBoxController.StartDialogue(previousDialogueTree, _oldSection, npcName, _oldIndex);
+   }
+
+   /// <summary>
+   /// This method will return the dialogue tree with the name that is passed as a parameter among the list of dialogue trees in the NPC. 
+   /// </summary>
+   private DialogueTree GetDialogueTreeFromName(string name)
+   {
+       DialogueTree returnTree = null;
+
+       foreach (DialogueTree tree in _conversationController.GetDialogueTrees())
+       {
+           if (tree.name.Equals(name))
+               returnTree = tree;
+       }
+
+       if (returnTree != null)
+           return returnTree;
+       return null;
    }
    
 }

--- a/Assets/Laboratory/Scripts/RegisterFish.cs
+++ b/Assets/Laboratory/Scripts/RegisterFish.cs
@@ -11,22 +11,22 @@ public class RegisterFish : MonoBehaviour
     public float conditionRight;
     public GameObject fishObject;
     public Weight weight;
-    private DialogueBoxController dialogueBoxController;
+    private DialogueBoxController _dialogueBoxController;
     public NpcTriggerDialogue NpcTriggerDialogue;
 
     private void Start()
     {
-        dialogueBoxController = FindObjectOfType<DialogueBoxController>();
+        _dialogueBoxController = FindObjectOfType<DialogueBoxController>();
     }
     private void OnTriggerEnter(Collider collisionObject)
     {
         if (collisionObject.GetComponent<Weight>() && collisionObject.gameObject.tag == "Bone")
         {
-            if (dialogueBoxController.dialogueTreeRestart != null && dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue")
+            if (_dialogueBoxController.dialogueTreeRestart != null && _dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue")
             {
-                if (dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[5].dialogue[1])
+                if (_dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[5].dialogue[1])
                 {
-                    dialogueBoxController.SkipLine();
+                    _dialogueBoxController.SkipLine();
                 }
             }
             weight = collisionObject.GetComponent<Weight>();
@@ -52,21 +52,18 @@ public class RegisterFish : MonoBehaviour
         }
         else if (collisionObject.gameObject.name == "basket_plastic")
         {
-            NpcTriggerDialogue.FindDialogueSection();
             collisionObject.transform.position = ObjectPositions.Instance._basketPosition;
             collisionObject.transform.rotation = ObjectPositions.Instance._basketRotation;
             NpcTriggerDialogue.Error5();
         }
         else if (collisionObject.gameObject.name == "counter_handheld")
         {
-            NpcTriggerDialogue.FindDialogueSection();
             collisionObject.transform.position = ObjectPositions.Instance._handheldCounterPosition;
             collisionObject.transform.rotation = ObjectPositions.Instance._handheldCounterRotation;
             NpcTriggerDialogue.Error5();
         }
         else if (collisionObject.gameObject.name == "MicroscopeSlideModel")
         {
-            NpcTriggerDialogue.FindDialogueSection();
             collisionObject.transform.position = ObjectPositions.Instance._microscopeSlidePosition;
             collisionObject.transform.rotation = ObjectPositions.Instance._microscopeSlideRotation;
             NpcTriggerDialogue.Error5();

--- a/Assets/Laboratory/Scripts/Scale/Scale.cs
+++ b/Assets/Laboratory/Scripts/Scale/Scale.cs
@@ -39,12 +39,10 @@ public class Scale : MonoBehaviour
     {
         if (!scaleOn)
         {
-            npcTriggerDialogue.FindDialogueSection();
             if (collisionObject.gameObject.name is "basket_plastic" or "counter_handheld" or "MicroscopeSlideModel" || collisionObject.gameObject.tag == "Bone")
             {
                 if (collisionObject.gameObject.name == "basket_plastic")
                 {
-                    
                     collisionObject.transform.position = ObjectPositions.Instance._basketPosition;
                     collisionObject.transform.rotation = ObjectPositions.Instance._basketRotation;
                     npcTriggerDialogue.Error1();
@@ -92,9 +90,6 @@ public class Scale : MonoBehaviour
         }
         else if (collisionObject.gameObject.name != "basket_plastic" && scaleOn)
         {
-            
-            npcTriggerDialogue.FindDialogueSection();
-
             if (collisionObject.gameObject.name is "counter_handheld" or "MicroscopeSlideModel")
             {
                 if (collisionObject.gameObject.name == "counter_handheld")
@@ -118,8 +113,6 @@ public class Scale : MonoBehaviour
                     npcTriggerDialogue.Error3();
                 }
             }
-          
-                
         }
     }
    

--- a/Assets/Laboratory/Scripts/Scale/ScaleButtons.cs
+++ b/Assets/Laboratory/Scripts/Scale/ScaleButtons.cs
@@ -47,18 +47,22 @@ public class ScaleButtons : MonoBehaviour
                 StopAllCoroutines();
                 scale.displayText.SetText("");
                 scale.audio.Play();
-                scale.scaleOn = true;
+                scale.scaleOn = false;
                 break;
             case ButtonType.Reset:
-                StopAllCoroutines();
-                scale.totalWeight = 0;
-                scale.displayText.SetText("000.0");
-                scale.audio.Play();
+                if (scale.scaleOn)
+                {
+                    StopAllCoroutines();
+                    scale.totalWeight = 0;
+                    scale.displayText.SetText("000.0");
+                    scale.audio.Play();
 
-                if (dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[2]) {
-                    dialogueBoxController.SkipLine();
+                    if (dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[2]) {
+                        dialogueBoxController.SkipLine();
                     
+                    } 
                 }
+                
 
                 break;
         }

--- a/Assets/Laboratory/Scripts/Scale/Weight.cs
+++ b/Assets/Laboratory/Scripts/Scale/Weight.cs
@@ -55,7 +55,7 @@ public class Weight : MonoBehaviour
 
         if (collision.GetType() == typeof(CapsuleCollider) && collision.GetComponent<Weight>())
         {
-            if (dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[3] && dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue" )
+            if ( dialogueBoxController.dialogueTreeRestart.name == "LarsDialogue" && dialogueBoxController._dialogueText.text == dialogueBoxController.dialogueTreeRestart.sections[1].dialogue[3])
             {
                 dialogueBoxController.SkipLine();
             }

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
@@ -125,6 +125,6 @@ public class ButtonSpawner : MonoBehaviour
         buttonTransfrom.localPosition = buttonLocation;
         button.GetComponentInChildren<TextMeshProUGUI>().text = "Speak";
         
-        _buttonsSpawned[0].GetComponent<Button>().onClick.AddListener(() => {_dialogueBoxController.StartDialogue(dialogueTree, 0, "NPC");});
+        _buttonsSpawned[0].GetComponent<Button>().onClick.AddListener(() => {_dialogueBoxController.StartDialogue(dialogueTree, 0, "NPC", 0);});
     }
 }

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ConversationController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ConversationController.cs
@@ -68,7 +68,7 @@ public class ConversationController : MonoBehaviour
             //_dialogueBoxController.startSpeakCanvas(_dialogueTree);
             _oldDialogueTree = _dialogueTree;
             if (_dialogueTree != null) {
-                _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC");
+                _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC", 0);
             } else {
                 // Commented out because not all NPC's should have a dialogue tree, therefor not an error
 
@@ -87,7 +87,7 @@ public class ConversationController : MonoBehaviour
             // Change the old tree to be the current tree, to ensure no repeats
             _oldDialogueTree = _dialogueTree;
             if (_dialogueTree != null) {
-                _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC");
+                _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC", 0);
             } else {
                 Debug.LogError("The dialogueTree of the NPC is null");
             }
@@ -101,7 +101,7 @@ public class ConversationController : MonoBehaviour
     /// </summary>
     public void DialogueTriggerAbsolute() {
         if (_dialogueTree != null) {
-            _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC");
+            _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC", 0);
         } else {
             Debug.LogError("The dialogueTree of the NPC is null");
         }
@@ -292,6 +292,14 @@ public class ConversationController : MonoBehaviour
 
     public DialogueTree GetDialogueTree() {
         return _dialogueTree;
+    }
+    
+    public DialogueTree GetOldDialogueTree() {
+        return _oldDialogueTree;
+    }
+    
+    public List<DialogueTree> GetDialogueTrees() {
+        return _dialogueTreesSOFormat;
     }
 
 

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -135,55 +135,59 @@ public class DialogueBoxController : MonoBehaviour
         dialogueTextRect.sizeDelta = new Vector2(150, 60);
         
         int dialogueSection = 0;
-        for (int i = element; i < dialogueTree.sections[section].dialogue.Length; i++)
+        if (element != -1)
         {
-            if (_pointingController != null && dialogueTree.sections[section].point)
-            {
-                _pointingController.GetComponent<PointingController>().ResetDirection(talkingNpc: this.gameObject);
-            }
+          for (int i = element; i < dialogueTree.sections[section].dialogue.Length; i++)
+          {
+              if (_pointingController != null && dialogueTree.sections[section].point)
+              {
+                  _pointingController.GetComponent<PointingController>().ResetDirection(talkingNpc: this.gameObject);
+              }
 
-            _animator.SetBool(_isPointingHash, false);
-            // Start talking animation
-            _animator.SetBool(_isTalkingHash, true);
-            StartCoroutine(revertToIdleAnimation());
-            _dialogueText.text = dialogueTree.sections[section].dialogue[i];
-            _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = true;
-            TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
-            // Invoke the dialogue changed event
-            m_DialogueChanged.Invoke(transform.name, dialogueTreeRestart.name, section, i);
-            _skipLineButton.SetActive(true);
+              _animator.SetBool(_isPointingHash, false);
+              // Start talking animation
+              _animator.SetBool(_isTalkingHash, true);
+              StartCoroutine(revertToIdleAnimation());
+              _dialogueText.text = dialogueTree.sections[section].dialogue[i];
+              _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = true;
+              TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
+              // Invoke the dialogue changed event
+              m_DialogueChanged.Invoke(transform.name, dialogueTreeRestart.name, section, i);
+              _skipLineButton.SetActive(true);
 
 
-            // Check if the current section should have disabled the skip line button
-            if (dialogueTree.sections[section].disabkeSkipLineButton)
-            {
-                _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = false;
-            }
-            // Check if the current dialogue section should have the NPC pointing
-            if (dialogueTree.sections[section].point)
-            {
-                if (_pointingController != null)
-                {
-                    _pointingController.GetComponent<PointingController>().ChangeDirection(section, talkingNpc: this.gameObject);
-                    _animator.SetBool(_isTalkingHash, false);
-                    _animator.SetBool(_isPointingHash, true);
-                }
-                else
-                {
-                    Debug.Log("PointingController not found in the scene");
-                }
+              // Check if the current section should have disabled the skip line button
+              if (dialogueTree.sections[section].disabkeSkipLineButton)
+              {
+                  _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = false;
+              }
+              // Check if the current dialogue section should have the NPC pointing
+              if (dialogueTree.sections[section].point)
+              {
+                  if (_pointingController != null)
+                  {
+                      _pointingController.GetComponent<PointingController>().ChangeDirection(section, talkingNpc: this.gameObject);
+                      _animator.SetBool(_isTalkingHash, false);
+                      _animator.SetBool(_isPointingHash, true);
+                  }
+                  else
+                  {
+                      Debug.Log("PointingController not found in the scene");
+                  }
 
-            }
+              }
 
-            while (!_skipLineTriggered)
-            {
+              while (!_skipLineTriggered)
+              {
 
-                _exitButton.SetActive(true);
-                yield return null;
-            }
-            _skipLineTriggered = false;
-            dialogueSection = section;
+                  _exitButton.SetActive(true);
+                  yield return null;
+              }
+              _skipLineTriggered = false;
+              dialogueSection = section;
+          }   
         }
+        
 
         if (!dialogueTree.sections[section].walkOrTurnTowardsAfterDialogue.Equals(string.Empty))
         {

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -65,6 +65,7 @@ public class DialogueBoxController : MonoBehaviour
         {
             m_DialogueChanged = new DialogueChanged();
         }
+        
         _pointingController = GameObject.Find("PointingController");
         dialogueEnded = false;
         // Assign the event camera
@@ -135,6 +136,8 @@ public class DialogueBoxController : MonoBehaviour
         dialogueTextRect.sizeDelta = new Vector2(150, 60);
         
         int dialogueSection = 0;
+        
+        // -1 means that the dialogue was a branchpoint and the script will skip to loading the branchpoint, instead of the standard dialogue when returning to the section
         if (element != -1)
         {
           for (int i = element; i < dialogueTree.sections[section].dialogue.Length; i++)
@@ -161,6 +164,7 @@ public class DialogueBoxController : MonoBehaviour
               {
                   _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = false;
               }
+              
               // Check if the current dialogue section should have the NPC pointing
               if (dialogueTree.sections[section].point)
               {
@@ -188,7 +192,6 @@ public class DialogueBoxController : MonoBehaviour
           }   
         }
         
-
         if (!dialogueTree.sections[section].walkOrTurnTowardsAfterDialogue.Equals(string.Empty))
         {
             GetComponent<WalkingNpc>().WalkPath(dialogueTree.sections[section].walkOrTurnTowardsAfterDialogue);


### PR DESCRIPTION
# What kind of change does this PR introduce?
feature

# What is the current behavior?
* The script checks for the current dialogue in Update which is unefficent and more complicated to work with. When returning to previous parts of the dialogue it is only able to return to a section and not a specific element in the dialogue tree. (#737) 
* and is unable to return to a branchpoint in the dialogue (#739) 

# What is the new behavior?
* Whenever the dialogue is changed an event is called which gives the relevant information about the dialogue. NpcTriggerDialogue listens to this event to call a method which is able to return to previous elements in the dialogue tree based on the incoming data of the current dialogue. With these changes the dialogue in the Labratory can return excactly where the player was when they did the mistake instead of restarting the section (#737)
* If the player makes a mistake while the dialogue is at a branchpoint the dialogue will be able to return to that point without breaking the game. (#739)  

