### PR TITLE
fix: lever being picked up

### DIFF
--- a/Assets/FishFactory/Scenes/QAStation.unity
+++ b/Assets/FishFactory/Scenes/QAStation.unity
@@ -47440,7 +47440,7 @@ PrefabInstance:
     - target: {fileID: 7438470712292323659, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: ExcludeTransformNames.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7438470712292323659, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
@@ -47455,7 +47455,7 @@ PrefabInstance:
     - target: {fileID: 7438470712292323659, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: ExcludeTransformNames.Array.data[2]
-      value: Bone
+      value: Hinge
       objectReference: {fileID: 0}
     - target: {fileID: 7438470712292323659, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}


### PR DESCRIPTION
# **What kind of change does this PR introduce?** 
 Bug fix


## **What is the current behavior?** (You can also link to an open issue here)
You can place the lever from the QAStation into your pocket #765 


## **What is the new behavior?** (if this is a feature change)
THis lever can't be pocketed anymore 

