### PR TITLE
fix: Discard Box in gutter station counts correctly

### DIFF
--- a/Assets/FishFactory/Scenes/QAStation.unity
+++ b/Assets/FishFactory/Scenes/QAStation.unity
@@ -49676,7 +49676,7 @@ PrefabInstance:
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.081
       objectReference: {fileID: 0}
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
@@ -50112,7 +50112,7 @@ PrefabInstance:
         type: 3}
       propertyPath: OnDiscard.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 193840343}
+      objectReference: {fileID: 715703715}
     - target: {fileID: 427450867588862522, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
       propertyPath: OnDiscard.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
@@ -50132,7 +50132,7 @@ PrefabInstance:
         type: 3}
       propertyPath: OnDiscardAfterCount.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 193840343}
+      objectReference: {fileID: 715703715}
     - target: {fileID: 427450867588862522, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
       propertyPath: OnDiscardAfterCount.m_PersistentCalls.m_Calls.Array.data[0].m_CallState

--- a/Assets/FishFactory/Scripts/DiscardBadFish.cs
+++ b/Assets/FishFactory/Scripts/DiscardBadFish.cs
@@ -46,7 +46,7 @@ public class DiscardBadFish : MonoBehaviour
             {
                 DestroyOldestFish();
             }
-        }
+        }  
     }
 
     /// <summary>
@@ -62,6 +62,7 @@ public class DiscardBadFish : MonoBehaviour
         )
         {
             OnDiscard.Invoke();
+            //Debug.Log(_discardedFish.Count.ToString());
             if (_discardedFish.Count == 10)
             {
                 OnDiscardAfterCount.Invoke();


### PR DESCRIPTION
### **What kind of change does this PR introduce?** 
Fix

### **What is the current behavior?** 
the discard box at the gutting station in the QA Station doesn't update the tablet once it get new fish, and has to wait for the tablet to be updated by something #771 

### **What is the new behavior?** (if this is a feature change)
It now updates the the tablet once it's got a new fish in it 

