### PR TITLE
feat: Add Error Responses in The Bleeding Station

### DIFF
--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e00f7924afa24219a5197b2a8fa8d48, type: 3}
+  m_Name: CutFishWrong
+  m_EditorClassIdentifier: 
+  shouldTriggerOnProximity: 1
+  speakButtonOnExit: 1
+  sections:
+  - dialogue:
+    - You need to stun the fish before you cut their gills.
+    endAfterDialogue: 1
+    walkOrTurnTowardsAfterDialogue: 
+    disabkeSkipLineButton: 1
+    pointAt: stunDevice
+    branchPoint:
+      question: 
+      answers: []
+  - dialogue:
+    - You're supposed to throw away the bad fish.
+    endAfterDialogue: 1
+    walkOrTurnTowardsAfterDialogue: 
+    disabkeSkipLineButton: 1
+    pointAt: FishDiscardBox (1)
+    branchPoint:
+      question: 
+      answers: []
+  - dialogue:
+    - Remember to cut the gills of the fish.
+    endAfterDialogue: 1
+    walkOrTurnTowardsAfterDialogue: 
+    disabkeSkipLineButton: 1
+    pointAt: 
+    branchPoint:
+      question: 
+      answers: []

--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     endAfterDialogue: 1
     walkOrTurnTowardsAfterDialogue: 
     disabkeSkipLineButton: 1
-    pointAt: stunDevice
+    pointAt: StunMachine_N
     branchPoint:
       question: 
       answers: []

--- a/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset.meta
+++ b/Assets/FishFactory/Resources/Prefabs/NPC/BleedingStation/DialogueTrees/CutFishWrong.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e967b1cf81bd0a4cb14326bcdd56ea7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scenes/BleedingStation.unity
+++ b/Assets/FishFactory/Scenes/BleedingStation.unity
@@ -223,12 +223,7 @@ PrefabInstance:
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
-      objectReference: {fileID: 0}
-    - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 24
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
@@ -2875,7 +2870,7 @@ Transform:
   - {fileID: 618008225}
   - {fileID: 27500355}
   m_Father: {fileID: 0}
-  m_RootOrder: 34
+  m_RootOrder: 27
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &146680940
 GameObject:
@@ -5187,7 +5182,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 33
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &237287083
 PrefabInstance:
@@ -8142,80 +8137,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 202280310}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &354087452
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2475764170342669484, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_Name
-      value: ControllerToolTipManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 6123226842121266758, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: MainMenu
-      value: 
-      objectReference: {fileID: 633140505}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: de743c9836296f64d98f2bdb13d4bb2b, type: 3}
 --- !u!1 &353684634
 GameObject:
   m_ObjectHideFlags: 0
@@ -8314,6 +8235,80 @@ Transform:
   m_Father: {fileID: 845123075}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 123.79401, y: -90, z: 0}
+--- !u!1001 &354087452
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2475764170342669484, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_Name
+      value: ControllerToolTipManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123226842121266758, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: MainMenu
+      value: 
+      objectReference: {fileID: 633140505}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de743c9836296f64d98f2bdb13d4bb2b, type: 3}
 --- !u!1 &354123162 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1792526361608126927, guid: 94cd43d357faa4065a013fcc39f489fd,
@@ -9780,12 +9775,7 @@ PrefabInstance:
     - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 37
-      objectReference: {fileID: 0}
-    - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 26
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
         type: 3}
@@ -12389,7 +12379,7 @@ Transform:
   - {fileID: 1604642308}
   - {fileID: 235032964}
   m_Father: {fileID: 0}
-  m_RootOrder: 28
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &512225208
 PrefabInstance:
@@ -15226,7 +15216,7 @@ Transform:
   - {fileID: 651487918}
   - {fileID: 2017470112}
   m_Father: {fileID: 0}
-  m_RootOrder: 29
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &641806242
 PrefabInstance:
@@ -16090,7 +16080,7 @@ PrefabInstance:
     - target: {fileID: 4376909619194593628, guid: ea7db852323fd6b4986a2685991fe1c5,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea7db852323fd6b4986a2685991fe1c5, type: 3}
@@ -16157,7 +16147,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 24
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &699117175 stripped
 Transform:
@@ -18739,7 +18729,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 26
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &855247290
 GameObject:
@@ -19886,7 +19876,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 25
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &906002513
 GameObject:
@@ -20842,7 +20832,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 31
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &949867684
 GameObject:
@@ -21421,7 +21411,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 28
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &967625006
 GameObject:
@@ -23687,6 +23677,116 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1042748263}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1045434288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1045434289}
+  - component: {fileID: 1045434292}
+  - component: {fileID: 1045434291}
+  - component: {fileID: 1045434290}
+  - component: {fileID: 1045434293}
+  m_Layer: 0
+  m_Name: CheckIfCut
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1045434289
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045434288}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.1246, y: -2.7415, z: 4.8164}
+  m_LocalScale: {x: 0.038069252, y: 0.4282679, z: 0.5871}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1386195888}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1045434290
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045434288}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1045434291
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045434288}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1045434292
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045434288}
+  m_Mesh: {fileID: 0}
+--- !u!114 &1045434293
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045434288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b8d4eb07cd205b49b9d69a3fda76c2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1054044869 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 405158047733232540, guid: cfeb1a1b35c01f843862f6a712829d70,
@@ -23762,7 +23862,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 27
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1069976056
 PrefabInstance:
@@ -23858,6 +23958,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 54cdcf45802444123b9f29f9266c9ce6, type: 3}
+--- !u!1 &1070057129
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1070057131}
+  - component: {fileID: 1070057130}
+  m_Layer: 0
+  m_Name: ErrorController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1070057130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1070057129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5d4fbe7dae9c494cb3d82929f9ac289, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _errorTree: {fileID: 11400000, guid: 8e967b1cf81bd0a4cb14326bcdd56ea7, type: 2}
+--- !u!4 &1070057131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1070057129}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.358735, y: 2.1620388, z: -6.732583}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 31
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1070357972
 GameObject:
   m_ObjectHideFlags: 0
@@ -24675,7 +24820,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 29
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1112485030
 PrefabInstance:
@@ -30734,6 +30879,7 @@ Transform:
   - {fileID: 1357538726}
   - {fileID: 1856962164}
   - {fileID: 2023949223}
+  - {fileID: 1045434289}
   m_Father: {fileID: 0}
   m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -32635,7 +32781,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 22
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1465624389
 GameObject:
@@ -34817,7 +34963,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 30
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1577446148
 PrefabInstance:
@@ -35864,7 +36010,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 32
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1607952123
 PrefabInstance:
@@ -40450,7 +40596,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 23
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1821697417
 PrefabInstance:
@@ -52087,7 +52233,7 @@ PrefabInstance:
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
@@ -56081,7 +56227,7 @@ Transform:
   m_Children:
   - {fileID: 427450868754643900}
   m_Father: {fileID: 0}
-  m_RootOrder: 36
+  m_RootOrder: 28
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 90}
 --- !u!23 &399934062157122987
 MeshRenderer:
@@ -57179,12 +57325,7 @@ PrefabInstance:
     - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
         type: 3}
       propertyPath: m_RootOrder
-      value: 38
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 27
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
         type: 3}

--- a/Assets/FishFactory/Scripts/Bleeding/CheckIfCut.cs
+++ b/Assets/FishFactory/Scripts/Bleeding/CheckIfCut.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using static FactoryFishState;
+using static FishSortingButton;
+
+public class CheckIfCut : MonoBehaviour
+{
+
+
+    private GameObject _errorController;
+
+    private void Start()
+    {
+        _errorController = GameObject.Find("ErrorController");
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.transform.parent.gameObject && other.name == "Head")
+        {
+            GameObject fish = other.transform.parent.transform.parent.gameObject;
+            Debug.Log(fish.tag + " is the tag of " + other.name + "'s parent object");
+            if (fish.tag == "Fish")
+            {
+                Debug.Log("hehe");
+                Tier fishTier = fish.GetComponent<FactoryFishState>().fishTier;
+                bool Stunned = fish.GetComponent<FactoryFishState>().Stunned;
+                bool correctlyBled = fish.GetComponent<FactoryFishState>().correctlyBled;
+
+                if (fishTier == Tier.BadQuality)
+                {
+                    _errorController.GetComponent<CutFishWrong>().CutBadFish();
+                    return;
+                }
+                if (!Stunned && !correctlyBled)
+                {
+                    _errorController.GetComponent<CutFishWrong>().ForgotToCutFish();
+                    return;
+                }
+                if (Stunned && !correctlyBled)
+                {
+                    _errorController.GetComponent<CutFishWrong>().ForgotToCutFish();
+                    return;
+                }
+            }
+
+        }
+    }
+}

--- a/Assets/FishFactory/Scripts/Bleeding/CheckIfCut.cs.meta
+++ b/Assets/FishFactory/Scripts/Bleeding/CheckIfCut.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b8d4eb07cd205b49b9d69a3fda76c2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scripts/Bleeding/CutFishWrong.cs
+++ b/Assets/FishFactory/Scripts/Bleeding/CutFishWrong.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting.Dependencies.NCalc;
+using UnityEngine;
+
+public class CutFishWrong : MonoBehaviour
+{
+
+    private DialogueBoxController _dialogueBoxController;
+    private ConversationController _conversationController;
+    [SerializeField] private DialogueTree _errorTree;
+
+    private string _currentDialogue = "", _oldDialogue = "";
+    private int _oldSection, _oldIndex, _currentSection, _currentIndex = 0;
+
+    private void Update()
+    {
+        if (_currentDialogue == "CutFishWrong" && !_dialogueBoxController.dialogueIsActive)
+        {
+            ReturnToBleedingInstruction();
+        }
+    }
+
+    void Start()
+    {
+        _dialogueBoxController = FindObjectOfType<DialogueBoxController>();
+        _conversationController = FindObjectOfType<ConversationController>();
+        _dialogueBoxController.m_DialogueChanged.AddListener(OnDialogueChanged);
+    }
+
+    public void CutNotStunnedFish()
+    {
+        if (_currentDialogue == "BleedingInstruction" || _currentDialogue == "CutFishWrong")// && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
+        {
+            _dialogueBoxController.StartDialogue(_errorTree, 0, "Bleeding station guide Bernard", 0);
+        }
+    }
+
+    public void CutBadFish() 
+    {
+        if (_currentDialogue == "BleedingInstruction" || _currentDialogue == "CutFishWrong")// && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
+        {
+            _dialogueBoxController.StartDialogue(_errorTree, 1, "Bleeding station guide Bernard", 0); 
+        }
+    }
+
+    public void ForgotToCutFish()
+    {
+        Debug.Log(_currentDialogue);
+        if (_currentDialogue == "BleedingInstruction")// && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
+        {
+            _dialogueBoxController.StartDialogue(_errorTree, 2, "Bleeding station guide Bernard", 0);
+        }
+    }
+
+    private void ReturnToBleedingInstruction()
+    {
+        _dialogueBoxController.StartDialogue(GetDialogueTreeFromName("BleedingInstruction"), 4, "Bleeding station guide Bernard", 0);
+        _dialogueBoxController.SkipLine();
+    }
+
+    private void OnDialogueChanged(string npcName, string dialogueTree, int section, int index)
+    {
+        // The variables for the old dialogue are set before the new dialogue is set, making it represent the previous duologue.
+        _oldDialogue = _currentDialogue;
+        _oldSection = _currentSection;
+        _oldIndex = _currentIndex;
+        // The variables store information about the current dialogue.
+        _currentDialogue = dialogueTree;
+        _currentSection = section;
+        _currentIndex = index;
+
+        if (dialogueTree == "CutFishWrong" && !_dialogueBoxController.dialogueIsActive) 
+        {
+            Debug.Log("grrrr");
+            //ReturnToBleedingInstruction();
+        }
+    }
+
+    private DialogueTree GetDialogueTreeFromName(string name)
+    {
+        DialogueTree returnTree = null;
+
+        foreach (DialogueTree tree in _conversationController.GetDialogueTrees())
+        {
+            if (tree.name.Equals(name))
+                returnTree = tree;
+        }
+
+        if (returnTree != null)
+            return returnTree;
+        return null;
+    }
+
+    private void OnDialogueEnded()
+    {
+        if (_currentDialogue == "CutFishWrong" && _dialogueBoxController.dialogueEnded)
+        {
+            ReturnToBleedingInstruction();
+        }
+    }
+}

--- a/Assets/FishFactory/Scripts/Bleeding/CutFishWrong.cs.meta
+++ b/Assets/FishFactory/Scripts/Bleeding/CutFishWrong.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5d4fbe7dae9c494cb3d82929f9ac289
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishFactory/Scripts/FactoryFishState.cs
+++ b/Assets/FishFactory/Scripts/FactoryFishState.cs
@@ -25,7 +25,7 @@ public class FactoryFishState : MonoBehaviour
     public GuttingState guttingState;
     public bool ContainsMetal = false;
     public bool Stunned;
-    public bool correctlyBled;
+    public bool correctlyBled;    
 
     // ------------ Editor Variables ------------
 
@@ -35,7 +35,7 @@ public class FactoryFishState : MonoBehaviour
     // ------------------ Private Variables ------------------
 
     public Material metalMat;
-
+    private GameObject _errorController;
     // ------------ Unity Functions ------------
 
     void Awake()
@@ -55,14 +55,21 @@ public class FactoryFishState : MonoBehaviour
         {
             StartCoroutine(AliveFish());
         }
-    }
+        
 
-    // ------------ Public Functions ------------
+        _errorController = GameObject.Find("ErrorController");
 
-    /// <summary>
-    /// When the player cuts the gills of the fish.
-    /// </summary>
-    public void CutFishGills()
+
+       
+
+}
+
+// ------------ Public Functions ------------
+
+/// <summary>
+/// When the player cuts the gills of the fish.
+/// </summary>
+public void CutFishGills()
     {
         Renderer fishMaterial = gameObject.transform.GetChild(0).GetComponent<Renderer>();
         
@@ -71,6 +78,7 @@ public class FactoryFishState : MonoBehaviour
             if (!GameManager.Instance)
                 return;
             GameManager.Instance.PlaySound("incorrect");
+            _errorController.GetComponent<CutFishWrong>().CutBadFish();
             return;
         }
         if (!Stunned && !correctlyBled)
@@ -80,6 +88,7 @@ public class FactoryFishState : MonoBehaviour
             if (!GameManager.Instance)
                 return;
             GameManager.Instance.PlaySound("incorrect");
+            _errorController.GetComponent<CutFishWrong>().CutNotStunnedFish();
             return;
         }
         if (Stunned && !correctlyBled)


### PR DESCRIPTION
### What kind of change does this PR introduce?
feature

### **What is the current behavior?**
when the player does an error when cutting the fish in the bleeding station they don't get a response from an NPC #774 

### **What is the new behavior?** 
Now when the player does an error whilst cutting the fish, the NPC beside it mentions what they did wrong, but only if he is standing in the right spot/ in the correct dialogue tree

