### PR TITLE
Refactored fish anti-stretch script and apply mechanism in all relevant scenes

### DIFF
--- a/Assets/FishFactory/Resources/Prefabs/Fish/FishFactoryBadFish.prefab
+++ b/Assets/FishFactory/Resources/Prefabs/Fish/FishFactoryBadFish.prefab
@@ -761,8 +761,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 573360791615036323}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -914,7 +914,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &8150832947165559640
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1187,8 +1187,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 7968289819078434106}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1340,7 +1340,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &6164764925110720205
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1834,7 +1834,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &744659603
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1902,8 +1902,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 4497055232872492743}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2372,8 +2372,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 654137428531625845}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2525,7 +2525,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &1259064525630186350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2813,7 +2813,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &5996645361607201540
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2881,8 +2881,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 5376487772531937559}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3330,7 +3330,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &1355815935
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3398,8 +3398,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 8776349924537100303}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3948,8 +3948,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 8542688777618602497}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4101,7 +4101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &2330949871227042094
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4389,7 +4389,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &1705924680
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4457,8 +4457,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 6310436565701880764}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4815,7 +4815,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 650007789173940065}
+  DropWhenStretchedScript: {fileID: 650007789173940065}
 --- !u!114 &682472284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4883,8 +4883,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 9101642283823060629}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/FishFactory/Resources/Prefabs/Fish/FishFactoryBadFish.prefab
+++ b/Assets/FishFactory/Resources/Prefabs/Fish/FishFactoryBadFish.prefab
@@ -711,18 +711,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -1147,18 +1135,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -1876,18 +1852,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -2356,18 +2320,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -2877,18 +2829,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -3406,18 +3346,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -3970,18 +3898,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -4491,18 +4407,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -4927,18 +4831,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 650007789173940065}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 650007789173940065}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount

--- a/Assets/FishFactory/Resources/Prefabs/Fish/FishFactorySalmon.prefab
+++ b/Assets/FishFactory/Resources/Prefabs/Fish/FishFactorySalmon.prefab
@@ -711,18 +711,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -1147,18 +1135,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -1862,18 +1838,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -2356,18 +2320,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -2863,18 +2815,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -3392,18 +3332,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
@@ -3970,18 +3898,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -4477,18 +4393,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
@@ -4913,18 +4817,6 @@ MonoBehaviour:
   onGrab:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2478399427380522642}
-        m_TargetAssemblyTypeName: DropWhenStretched, Scripts
-        m_MethodName: DistanceLength
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 2478399427380522642}
         m_TargetAssemblyTypeName: DropWhenStretched, Scripts
         m_MethodName: IncrementGrabCount

--- a/Assets/FishFactory/Resources/Prefabs/Fish/FishFactorySalmon.prefab
+++ b/Assets/FishFactory/Resources/Prefabs/Fish/FishFactorySalmon.prefab
@@ -761,8 +761,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 3068821912412757714}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -914,7 +914,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &1007936390889778132
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1187,8 +1187,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 8711300024869104656}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1340,7 +1340,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &8452365175430266760
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1888,8 +1888,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 1104228822891812903}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1972,7 +1972,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &1990352875118773114
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2372,8 +2372,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 4566324943558228070}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2525,7 +2525,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &3490729255513303341
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2867,8 +2867,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 870878670085934679}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2951,7 +2951,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &7598101746438735289
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3384,8 +3384,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 5294512501093472770}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3468,7 +3468,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &6381045570279958725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3948,8 +3948,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 6737936810270135621}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4101,7 +4101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &2498892570112191532
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4443,8 +4443,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 6573457290574925875}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4527,7 +4527,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &5298251503363955698
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4869,8 +4869,8 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 599486538380371366}
-        m_TargetAssemblyTypeName: WhichJointGrabbed, Scripts
-        m_MethodName: RemoveGrabbedJoint
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4953,7 +4953,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grabbed: 0
-  WhenStretched: {fileID: 2478399427380522642}
+  DropWhenStretchedScript: {fileID: 2478399427380522642}
 --- !u!114 &9064314040347262209
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Scenes/BleedingStation.unity
+++ b/Assets/FishFactory/Scenes/BleedingStation.unity
@@ -223,12 +223,7 @@ PrefabInstance:
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
-      objectReference: {fileID: 0}
-    - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 24
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
@@ -2875,7 +2870,7 @@ Transform:
   - {fileID: 618008225}
   - {fileID: 27500355}
   m_Father: {fileID: 0}
-  m_RootOrder: 34
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &146680940
 GameObject:
@@ -5187,7 +5182,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 33
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &237287083
 PrefabInstance:
@@ -8142,80 +8137,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 202280310}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &354087452
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2475764170342669484, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: m_Name
-      value: ControllerToolTipManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 6123226842121266758, guid: de743c9836296f64d98f2bdb13d4bb2b,
-        type: 3}
-      propertyPath: MainMenu
-      value: 
-      objectReference: {fileID: 633140505}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: de743c9836296f64d98f2bdb13d4bb2b, type: 3}
 --- !u!1 &353684634
 GameObject:
   m_ObjectHideFlags: 0
@@ -8314,6 +8235,80 @@ Transform:
   m_Father: {fileID: 845123075}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 123.79401, y: -90, z: 0}
+--- !u!1001 &354087452
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2475764170342669484, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: m_Name
+      value: ControllerToolTipManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123226842121266758, guid: de743c9836296f64d98f2bdb13d4bb2b,
+        type: 3}
+      propertyPath: MainMenu
+      value: 
+      objectReference: {fileID: 633140505}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de743c9836296f64d98f2bdb13d4bb2b, type: 3}
 --- !u!1 &354123162 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1792526361608126927, guid: 94cd43d357faa4065a013fcc39f489fd,
@@ -9776,11 +9771,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
         type: 3}
@@ -12389,7 +12379,7 @@ Transform:
   - {fileID: 1604642308}
   - {fileID: 235032964}
   m_Father: {fileID: 0}
-  m_RootOrder: 28
+  m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &512225208
 PrefabInstance:
@@ -15226,7 +15216,7 @@ Transform:
   - {fileID: 651487918}
   - {fileID: 2017470112}
   m_Father: {fileID: 0}
-  m_RootOrder: 29
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &641806242
 PrefabInstance:
@@ -16157,7 +16147,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 24
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &699117175 stripped
 Transform:
@@ -18739,7 +18729,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 26
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &855247290
 GameObject:
@@ -19886,7 +19876,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 25
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &906002513
 GameObject:
@@ -20842,7 +20832,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 31
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &949867684
 GameObject:
@@ -21421,7 +21411,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 28
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &967625006
 GameObject:
@@ -23762,7 +23752,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 27
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1069976056
 PrefabInstance:
@@ -24675,7 +24665,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 29
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1112485030
 PrefabInstance:
@@ -32635,7 +32625,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 22
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1465624389
 GameObject:
@@ -34817,7 +34807,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 30
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1577446148
 PrefabInstance:
@@ -35864,7 +35854,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 32
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1607952123
 PrefabInstance:
@@ -40450,7 +40440,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 510809922}
-  m_RootOrder: 23
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1821697417
 PrefabInstance:
@@ -52087,7 +52077,7 @@ PrefabInstance:
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
@@ -56081,7 +56071,7 @@ Transform:
   m_Children:
   - {fileID: 427450868754643900}
   m_Father: {fileID: 0}
-  m_RootOrder: 36
+  m_RootOrder: 27
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 90}
 --- !u!23 &399934062157122987
 MeshRenderer:
@@ -57169,90 +57159,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 22dca1a94fb2342fd860283f441e410c, type: 3}
---- !u!1001 &3653119826302373783
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 38
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 27
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropLeft.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropRight.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966262, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_Name
-      value: DropObject
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 214d510594ae65b4eaaffffd87284f39, type: 3}
 --- !u!33 &3876471887425270015
 MeshFilter:
   m_ObjectHideFlags: 0

--- a/Assets/FishFactory/Scenes/QAStation.unity
+++ b/Assets/FishFactory/Scenes/QAStation.unity
@@ -1042,7 +1042,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 36
+  m_RootOrder: 35
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &53256464
 GameObject:
@@ -1336,7 +1336,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 44
+  m_RootOrder: 43
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &68490990
 GameObject:
@@ -1747,7 +1747,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 40
+  m_RootOrder: 39
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &78267387
 PrefabInstance:
@@ -2913,7 +2913,7 @@ Transform:
   m_Children:
   - {fileID: 564463887}
   m_Father: {fileID: 0}
-  m_RootOrder: 21
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &142156153
 GameObject:
@@ -3858,7 +3858,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 23
+  m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &191949741
 GameObject:
@@ -4039,7 +4039,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &193840347
 MonoBehaviour:
@@ -4170,7 +4170,7 @@ PrefabInstance:
     - target: {fileID: 4330640650074883635, guid: 5d9cb0bf37420f547a3d16e4ec82094a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4330640650074883635, guid: 5d9cb0bf37420f547a3d16e4ec82094a,
         type: 3}
@@ -6790,7 +6790,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 35
+  m_RootOrder: 34
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &306741723
 PrefabInstance:
@@ -7341,95 +7341,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cfeb1a1b35c01f843862f6a712829d70, type: 3}
---- !u!1001 &347217119
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -11.481417
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.19455719
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -9.845406
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966260, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropLeft.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropRight.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropLeft.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: TryRelease
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966261, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: StretchDropRight.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: TryRelease
-      objectReference: {fileID: 0}
-    - target: {fileID: 3653119827377966262, guid: 214d510594ae65b4eaaffffd87284f39,
-        type: 3}
-      propertyPath: m_Name
-      value: DropObject
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 214d510594ae65b4eaaffffd87284f39, type: 3}
 --- !u!1 &356434111
 GameObject:
   m_ObjectHideFlags: 0
@@ -7687,7 +7598,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 33
+  m_RootOrder: 32
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &372256609
 GameObject:
@@ -8543,7 +8454,7 @@ PrefabInstance:
     - target: {fileID: 6158762689090928347, guid: ce8153806c31de74dae2a33b9f29a506,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6158762689090928347, guid: ce8153806c31de74dae2a33b9f29a506,
         type: 3}
@@ -8852,7 +8763,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 46
+  m_RootOrder: 45
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &438545615
 GameObject:
@@ -9480,7 +9391,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 39
+  m_RootOrder: 38
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &476875149
 GameObject:
@@ -9876,7 +9787,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 34
+  m_RootOrder: 33
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &483951873
 PrefabInstance:
@@ -12020,7 +11931,7 @@ Transform:
   - {fileID: 12100285}
   - {fileID: 1916015217}
   m_Father: {fileID: 0}
-  m_RootOrder: 22
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &551094361
 PrefabInstance:
@@ -14305,7 +14216,7 @@ PrefabInstance:
     - target: {fileID: 5564782313871557707, guid: 25e6a7ec6a0b3594da2640c242dc83b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 5564782313871557707, guid: 25e6a7ec6a0b3594da2640c242dc83b3,
         type: 3}
@@ -14859,7 +14770,7 @@ PrefabInstance:
     - target: {fileID: 4376909619194593626, guid: ea7db852323fd6b4986a2685991fe1c5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 4376909619194593626, guid: ea7db852323fd6b4986a2685991fe1c5,
         type: 3}
@@ -15251,7 +15162,7 @@ PrefabInstance:
     - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 3690033453063038195, guid: ec2da074d6520b2458f58e6c014dec5b,
         type: 3}
@@ -16053,7 +15964,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 30
+  m_RootOrder: 29
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &782167756 stripped
 Transform:
@@ -16230,7 +16141,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 28
+  m_RootOrder: 27
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &787757073
 GameObject:
@@ -16552,7 +16463,7 @@ PrefabInstance:
     - target: {fileID: 646092130593344030, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 646092130593344030, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -18354,7 +18265,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 27
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &877948076
 GameObject:
@@ -18984,7 +18895,7 @@ PrefabInstance:
     - target: {fileID: 5582427761267303792, guid: aabd3c08d3b33f54dafb54f8da691fd9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5582427761267303792, guid: aabd3c08d3b33f54dafb54f8da691fd9,
         type: 3}
@@ -22680,7 +22591,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 31
+  m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1090630078
 GameObject:
@@ -23479,7 +23390,7 @@ PrefabInstance:
     - target: {fileID: 4234165376520476066, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4234165376520476066, guid: cd83d7ec3c8f7d449b1cb93495a9c1b1,
         type: 3}
@@ -23729,7 +23640,7 @@ Transform:
   - {fileID: 877948077}
   - {fileID: 241197404}
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1134845009
 GameObject:
@@ -24616,7 +24527,7 @@ Transform:
   - {fileID: 1203797244}
   - {fileID: 1188212065}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1188212064
 GameObject:
@@ -25190,7 +25101,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 32
+  m_RootOrder: 31
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1223214206
 GameObject:
@@ -26044,7 +25955,7 @@ PrefabInstance:
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
@@ -28151,7 +28062,7 @@ Transform:
   - {fileID: 1091127035}
   - {fileID: 616715203}
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1391881204
 GameObject:
@@ -29082,7 +28993,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 29
+  m_RootOrder: 28
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1452012261
 GameObject:
@@ -29147,7 +29058,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 37
+  m_RootOrder: 36
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1459722761
 GameObject:
@@ -29703,7 +29614,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 38
+  m_RootOrder: 37
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1482121686
 GameObject:
@@ -29768,7 +29679,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 41
+  m_RootOrder: 40
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1483066916
 GameObject:
@@ -30014,7 +29925,7 @@ PrefabInstance:
     - target: {fileID: 2281686386275440644, guid: fa1492a389a7b4c4082875a471f440a4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2281686386275440644, guid: fa1492a389a7b4c4082875a471f440a4,
         type: 3}
@@ -30494,7 +30405,7 @@ PrefabInstance:
     - target: {fileID: 2669687472096218853, guid: d81e12ec6db043045add9d1b413cd126,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2669687472096218853, guid: d81e12ec6db043045add9d1b413cd126,
         type: 3}
@@ -30638,7 +30549,7 @@ Transform:
   - {fileID: 1693748220}
   - {fileID: 1559578549}
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1527736548
 PrefabInstance:
@@ -31379,7 +31290,7 @@ PrefabInstance:
     - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 1551040705506976700, guid: de743c9836296f64d98f2bdb13d4bb2b,
         type: 3}
@@ -32865,7 +32776,7 @@ Transform:
   - {fileID: 782167756}
   - {fileID: 787757074}
   m_Father: {fileID: 0}
-  m_RootOrder: 25
+  m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1619380501
 PrefabInstance:
@@ -33358,7 +33269,7 @@ Transform:
   - {fileID: 165989176}
   - {fileID: 1002498030}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1649111212
 PrefabInstance:
@@ -35005,7 +34916,7 @@ PrefabInstance:
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
@@ -35467,7 +35378,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 47
+  m_RootOrder: 46
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &1769054453
 GameObject:
@@ -36226,7 +36137,7 @@ PrefabInstance:
     - target: {fileID: 574394517555101187, guid: 4a95e8acfe72e87429a0fdc85c31c658,
         type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 574394517555101187, guid: 4a95e8acfe72e87429a0fdc85c31c658,
         type: 3}
@@ -47030,7 +46941,7 @@ PrefabInstance:
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 7028846462367453590, guid: 0f2bcfe3b2900db469a02abdad5e5fc7,
         type: 3}
@@ -49336,7 +49247,7 @@ PrefabInstance:
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6469546868339267633, guid: 2258f33e244b27b488342f226992f445,
         type: 3}
@@ -49691,7 +49602,7 @@ PrefabInstance:
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 172303580937983709, guid: 04669426bd122de4e88a1311b168d4d0,
         type: 3}
@@ -49954,7 +49865,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 42
+  m_RootOrder: 41
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
 --- !u!4 &2019994081 stripped
 Transform:
@@ -51391,7 +51302,7 @@ PrefabInstance:
     - target: {fileID: 4376909619194593626, guid: ea7db852323fd6b4986a2685991fe1c5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 4376909619194593626, guid: ea7db852323fd6b4986a2685991fe1c5,
         type: 3}
@@ -55546,7 +55457,7 @@ PrefabInstance:
     - target: {fileID: 8276397956611906916, guid: 4f033eb3adbe45e41bffa195062a33b8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 8276397956611906916, guid: 4f033eb3adbe45e41bffa195062a33b8,
         type: 3}

--- a/Assets/FishFactory/Scripts/DropWhenStretched.cs
+++ b/Assets/FishFactory/Scripts/DropWhenStretched.cs
@@ -6,67 +6,61 @@ using System.Linq;
 public class DropWhenStretched : MonoBehaviour
 {
     [SerializeField] private Transform Head;
-    [SerializeField] private GameObject Armature;
     [SerializeField] private float StretchLimit = .15f;
-    private GameObject GrabbedJoint;
-    private List<float> distances = new();
-    private int GrabCount = 0;
-    private int FishCollides = 0;
-    private Grabber playerGrabberLeft, playerGrabberRight;
+    private GameObject _grabbedJoint;
+    private List<float> _distances = new();
+    private int _grabCount = 0;
+    private int _fishCollides = 0;
+    private Grabber _playerGrabberLeft, _playerGrabberRight;
+    private float _waitTime = 0;
 
-    private float WaitBeforeDrop = 0;
-    // Update is called once per frame
 
     private void Awake()
     {
         if (Head == null)
             Debug.LogError("Head field is null! This field should be set to the armature's head joint!");
 
-        if (Armature == null)
-            Debug.LogError("Armature field is null! Field should be set to fish object's armature!");
-
         InitialJointDistances();
     }
 
+    // Update is called once per frame
     void Update()
     {
         // getting the player hand grabbers. they are not immediately accessible, so they are fetched here
-        if (playerGrabberLeft == null || playerGrabberRight == null)
+        if (_playerGrabberLeft == null || _playerGrabberRight == null)
         {
             GameObject playerRig = GameManager.Instance.GetPlayerRig();
             if (playerRig != null)
             {
                 List<Grabber> grabbers = playerRig.GetComponentsInChildren<Grabber>().ToList();
-                playerGrabberLeft = grabbers.Find(x => x.transform.parent.name == "LeftController");
-                playerGrabberRight = grabbers.Find(x => x.transform.parent.name == "RightController");
+                _playerGrabberLeft = grabbers.Find(x => x.transform.parent.name == "LeftController");
+                _playerGrabberRight = grabbers.Find(x => x.transform.parent.name == "RightController");
             }
             return;
         }
 
         // return when fish is not grabbed, or if held with one hand while touching the sorting machine's sticky surface. prevents unneccesary calculations and unwanted anti-stretch corrections
-        if (GrabCount == 0 || FishCollides > 0 && GrabCount < 2)
+        if (_grabCount == 0 || _fishCollides > 0 && _grabCount < 2)
             return;
 
         // make anti-stretch corrections if fish is currently stretched and enough time has passed since last correction. waiting prevents wild and rapid corrections
-        if (JointDistancesTooGreat() && Time.time - WaitBeforeDrop >= 1f)
+        if (JointDistancesTooGreat() && Time.time - _waitTime >= 2f)
         {
-            WaitBeforeDrop = Time.time;
-            if (GrabCount == 2) // select random hand and make it drop its held fish joint
+            _waitTime = Time.time;
+            if (_grabCount == 2) // select random hand and make it drop its held fish joint
             {
                 if (Random.value >= 0.5)
-                    playerGrabberLeft.TryRelease();
+                    _playerGrabberLeft.TryRelease();
                 else
-                    playerGrabberRight.TryRelease();
-                return;
+                    _playerGrabberRight.TryRelease();
             }
-                
-            if (GrabCount == 1) // find which joint the player is holding and move all joints towards it. prevents fish from latching into objects and becoming stretched when player moves held joint
+            else if (_grabCount == 1) // find which joint the player is holding and move all joints towards it. prevents fish from latching into objects and becoming stretched when player moves held joint
             {
                 foreach (WhichJointGrabbed Joint in GetComponentsInChildren<WhichJointGrabbed>())
                 {
                     if (Joint.Grabbed)
                     {
-                        GrabbedJoint = Joint.gameObject;
+                        _grabbedJoint = Joint.gameObject;
                         break;
                     }
                 }
@@ -74,7 +68,7 @@ public class DropWhenStretched : MonoBehaviour
                 foreach (WhichJointGrabbed Joint in GetComponentsInChildren<WhichJointGrabbed>())
                 {
                     if (!Joint.Grabbed)
-                        Joint.transform.position = GrabbedJoint.transform.position;
+                        Joint.GetComponent<Rigidbody>().position = _grabbedJoint.transform.position;
                 }
             }
         }      
@@ -87,12 +81,12 @@ public class DropWhenStretched : MonoBehaviour
     /// </summary>
     public void InitialJointDistances()
     {
-        if (distances.Count == 0)
+        if (_distances.Count == 0)
         {
             foreach (WhichJointGrabbed Joint in GetComponentsInChildren<WhichJointGrabbed>())
             {
                 if (Joint.gameObject.name != "Head")
-                    distances.Add(Vector3.Distance(Head.transform.position, Joint.transform.position));
+                    _distances.Add(Vector3.Distance(Head.transform.position, Joint.transform.position));
             }
         }
     }
@@ -100,13 +94,13 @@ public class DropWhenStretched : MonoBehaviour
     /// <summary>
     /// Called by fish joints' OnGrab event
     /// </summary>
-    public void IncrementGrabCount() => GrabCount++;
+    public void IncrementGrabCount() => _grabCount++;
 
 
     /// <summary>
     /// Called by fish joints' OnGrab event
     /// </summary>
-    public void DecrementGrabCount() => GrabCount--;
+    public void DecrementGrabCount() => _grabCount--;
 
 
     /// <summary>
@@ -116,7 +110,7 @@ public class DropWhenStretched : MonoBehaviour
     /// <returns></returns>
     private bool JointDistancesTooGreat()
     {
-        if (distances.Count < 8)
+        if (_distances.Count < 8)
             return false;
 
         int i = 0;
@@ -124,9 +118,9 @@ public class DropWhenStretched : MonoBehaviour
         {
             if (i != 0)
             {
-                float distance = Vector3.Distance(Armature.transform.GetChild(0).transform.position, Joint.transform.position);
+                float distance = Vector3.Distance(Head.transform.position, Joint.transform.position);
 
-                if (distance >= distances[i - 1] + StretchLimit)
+                if (distance >= _distances[i - 1] + StretchLimit)
                     return true;
             }
             i++;
@@ -137,11 +131,11 @@ public class DropWhenStretched : MonoBehaviour
     /// <summary>
     /// Tell that a joint collides with some object that should disable certain corrections, like the sticky surface of the sorting maching.
     /// </summary>
-    public void JointCollisionIncrease() => FishCollides++;
+    public void JointCollisionIncrease() => _fishCollides++;
 
 
     /// <summary>
     /// Tell that a joint no longer collides with some object that should disable certain corrections, like the sticky surface of the sorting maching.
     /// </summary>
-    public void JointCollisionDecrease() => FishCollides--;
+    public void JointCollisionDecrease() => _fishCollides--;
 }

--- a/Assets/FishFactory/Scripts/StopConveyorButton.cs
+++ b/Assets/FishFactory/Scripts/StopConveyorButton.cs
@@ -10,7 +10,8 @@ public class StopConveyorButton : MonoBehaviour
     void Start()
     {
         _bleedingGuide = GameObject.Find("Bleeding station guide Bernard");
-        _dialogueBoxController = _bleedingGuide.GetComponent<DialogueBoxController>();
+        if (_bleedingGuide != null)
+            _dialogueBoxController = _bleedingGuide.GetComponent<DialogueBoxController>();
     }
     /// <summary>
     /// Toggles the main task on and off
@@ -18,7 +19,7 @@ public class StopConveyorButton : MonoBehaviour
     public void ToggleTaskOn()
     {
         GameManager.Instance.ToggleTaskOn();
-        if (_dialogueBoxController.dialogueTreeRestart.name == "BleedingInstruction" && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
+        if (_dialogueBoxController != null && _dialogueBoxController.dialogueTreeRestart.name == "BleedingInstruction" && _dialogueBoxController._dialogueText.text == _dialogueBoxController.dialogueTreeRestart.sections[4].dialogue[0])
         {
             _dialogueBoxController.SkipLine();
         }

--- a/Assets/FishFactory/Scripts/WhichJointGrabbed.cs
+++ b/Assets/FishFactory/Scripts/WhichJointGrabbed.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class WhichJointGrabbed : MonoBehaviour
 {
-    public bool Grabbed = false;
+    [HideInInspector] public bool Grabbed = false;
     [SerializeField] private DropWhenStretched WhenStretched;
     public void SetGrabbedJoint()
     {

--- a/Assets/FishFactory/Scripts/WhichJointGrabbed.cs
+++ b/Assets/FishFactory/Scripts/WhichJointGrabbed.cs
@@ -3,26 +3,21 @@ using UnityEngine;
 public class WhichJointGrabbed : MonoBehaviour
 {
     [HideInInspector] public bool Grabbed = false;
-    [SerializeField] private DropWhenStretched WhenStretched;
-    public void SetGrabbedJoint()
-    {
-        Grabbed = true;
-    }
+    [SerializeField] private DropWhenStretched DropWhenStretchedScript;
 
-    public void RemoveGrabbedJoint()
-    {
-        Grabbed = false;
-    }
+    public void SetGrabbedJoint() => Grabbed = true;
+
+    public void UnsetGrabbedJoint() => Grabbed = false;
 
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("SortingSquare"))
-            WhenStretched.JointCollisionIncrease();
+            DropWhenStretchedScript.JointCollisionIncrease();
     }
 
     private void OnTriggerExit(Collider other)
     {
         if (other.CompareTag("SortingSquare"))
-            WhenStretched.JointCollisionDecrease();
+            DropWhenStretchedScript.JointCollisionDecrease();
     }
 }

--- a/Assets/FishWelfare/Prefabs/salmon_rigged_1lice_2gill.prefab
+++ b/Assets/FishWelfare/Prefabs/salmon_rigged_1lice_2gill.prefab
@@ -529,6 +529,7 @@ GameObject:
   - component: {fileID: 752814164}
   - component: {fileID: 752814165}
   - component: {fileID: 1119661658}
+  - component: {fileID: 674346738259270151}
   m_Layer: 13
   m_Name: Neck
   m_TagString: Bone
@@ -736,9 +737,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 674346738259270151}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -748,9 +749,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -775,9 +776,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 674346738259270151}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -787,9 +788,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -916,6 +917,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &674346738259270151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 273438476667798305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &1777015713573393535
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,6 +946,7 @@ GameObject:
   - component: {fileID: 108685240}
   - component: {fileID: 117183120}
   - component: {fileID: 1171745047}
+  - component: {fileID: 3108103156841675890}
   m_Layer: 13
   m_Name: Back_5
   m_TagString: Bone
@@ -1119,9 +1135,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3108103156841675890}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1131,9 +1147,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1158,10 +1174,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 3108103156841675890}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1170,9 +1186,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1318,6 +1334,20 @@ MonoBehaviour:
     m_Bits: 0
   storedPosition: {x: 0, y: 0, z: 0}
   storedRotation: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3108103156841675890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777015713573393535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &2168024215688232703
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,6 +1456,7 @@ GameObject:
   - component: {fileID: 18663942}
   - component: {fileID: 744659602}
   - component: {fileID: 744659603}
+  - component: {fileID: 3979619736691713123}
   m_Layer: 13
   m_Name: Back_1
   m_TagString: Bone
@@ -1702,9 +1733,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3979619736691713123}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1714,9 +1745,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1741,9 +1772,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3979619736691713123}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1753,9 +1784,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1813,6 +1844,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &3979619736691713123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2322968982182209632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &3814371106168548784
 GameObject:
   m_ObjectHideFlags: 0
@@ -1953,6 +1998,7 @@ GameObject:
   - component: {fileID: 1043450806}
   - component: {fileID: 2001593012}
   - component: {fileID: 2001593013}
+  - component: {fileID: 9131761976948986550}
   m_Layer: 13
   m_Name: Head
   m_TagString: Bone
@@ -2160,9 +2206,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 9131761976948986550}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2172,9 +2218,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2199,9 +2245,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 9131761976948986550}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2211,9 +2257,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2340,6 +2386,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &9131761976948986550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4648646452388991490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &6048210018162169073
 GameObject:
   m_ObjectHideFlags: 0
@@ -2355,6 +2415,7 @@ GameObject:
   - component: {fileID: 5996645361607201537}
   - component: {fileID: 5996645361607201539}
   - component: {fileID: 5996645361607201540}
+  - component: {fileID: 2107256314702391542}
   m_Layer: 13
   m_Name: Back_2
   m_TagString: Bone
@@ -2631,9 +2692,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 2107256314702391542}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2643,9 +2704,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2670,9 +2731,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 2107256314702391542}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2682,9 +2743,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2742,6 +2803,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &2107256314702391542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6048210018162169073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &6623024931096006545
 GameObject:
   m_ObjectHideFlags: 0
@@ -2850,6 +2925,7 @@ GameObject:
   - component: {fileID: 1355815933}
   - component: {fileID: 1355815934}
   - component: {fileID: 1355815935}
+  - component: {fileID: 7915287345755942082}
   m_Layer: 13
   m_Name: Tail_end
   m_TagString: Bone
@@ -3124,9 +3200,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7915287345755942082}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3136,9 +3212,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3163,10 +3239,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 7915287345755942082}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3175,9 +3251,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3235,6 +3311,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &7915287345755942082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6748978213728608801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &6915616972181788328
 GameObject:
   m_ObjectHideFlags: 0
@@ -3249,6 +3339,7 @@ GameObject:
   - component: {fileID: 919132148199949408}
   - component: {fileID: 919132148199949410}
   - component: {fileID: 919132148199949411}
+  - component: {fileID: 1191779298730865936}
   m_Layer: 6
   m_Name: salmon_rigged_1lice_2gill
   m_TagString: Fish
@@ -3422,7 +3513,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _killPlane: -3
   _useStartPositionAsSpawnPosition: 0
-  _useSpawnObject: 0
   _spawnObject: {fileID: 0}
   _respawnPosition: {x: 0, y: 0, z: 0}
   _respawnRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -3466,6 +3556,35 @@ MonoBehaviour:
   startTank: {fileID: 0}
   endTank: {fileID: 0}
   sedationTimer: 3
+  m_OnFishCalmedDown:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnBroughtToTable:
+    m_PersistentCalls:
+      m_Calls: []
+  BringFishStepCompleted: 0
+  m_OnInspected:
+    m_PersistentCalls:
+      m_Calls: []
+  HasBeenInspected: 0
+  m_OnPlacedInRecoveryTank:
+    m_PersistentCalls:
+      m_Calls: []
+  PlacedInRecoveryTank: 0
+--- !u!114 &1191779298730865936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915616972181788328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee0474ab07aa154b9bf194a948b701f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Head: {fileID: 7589862318644897614}
+  Armature: {fileID: 3814371106168548784}
 --- !u!1 &7132867527503714408
 GameObject:
   m_ObjectHideFlags: 0
@@ -3481,6 +3600,7 @@ GameObject:
   - component: {fileID: 1253310518}
   - component: {fileID: 1253310519}
   - component: {fileID: 1253310520}
+  - component: {fileID: 9017802498784965522}
   m_Layer: 13
   m_Name: Back_4
   m_TagString: Bone
@@ -3688,9 +3808,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 9017802498784965522}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3700,9 +3820,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3727,10 +3847,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 9017802498784965522}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3739,9 +3859,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3868,6 +3988,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &9017802498784965522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132867527503714408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &7531260673488108337
 GameObject:
   m_ObjectHideFlags: 0
@@ -3883,6 +4017,7 @@ GameObject:
   - component: {fileID: 569489947}
   - component: {fileID: 1705924679}
   - component: {fileID: 1705924680}
+  - component: {fileID: 8957301237697908306}
   m_Layer: 13
   m_Name: Back_3
   m_TagString: Bone
@@ -4159,9 +4294,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8957301237697908306}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4171,9 +4306,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4198,10 +4333,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 8957301237697908306}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4210,9 +4345,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4270,6 +4405,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &8957301237697908306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7531260673488108337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}
 --- !u!1 &7852440317991942239
 GameObject:
   m_ObjectHideFlags: 0
@@ -4285,6 +4434,7 @@ GameObject:
   - component: {fileID: 415868202}
   - component: {fileID: 682472283}
   - component: {fileID: 682472284}
+  - component: {fileID: 6699244201120034485}
   m_Layer: 13
   m_Name: Tail
   m_TagString: Bone
@@ -4561,9 +4711,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6699244201120034485}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4573,9 +4723,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4600,10 +4750,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 6699244201120034485}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4612,9 +4762,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1191779298730865936}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4672,3 +4822,17 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &6699244201120034485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7852440317991942239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 1191779298730865936}

--- a/Assets/FishWelfare/Prefabs/salmon_rigged_4lice_1gill.prefab
+++ b/Assets/FishWelfare/Prefabs/salmon_rigged_4lice_1gill.prefab
@@ -529,6 +529,7 @@ GameObject:
   - component: {fileID: 752814164}
   - component: {fileID: 752814165}
   - component: {fileID: 1119661658}
+  - component: {fileID: 5194395074130584647}
   m_Layer: 13
   m_Name: Neck
   m_TagString: Bone
@@ -736,9 +737,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5194395074130584647}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -748,9 +749,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -775,9 +776,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5194395074130584647}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -787,9 +788,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -916,6 +917,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &5194395074130584647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 273438476667798305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &1777015713573393535
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,6 +946,7 @@ GameObject:
   - component: {fileID: 108685240}
   - component: {fileID: 117183120}
   - component: {fileID: 1171745047}
+  - component: {fileID: 5005036422705746442}
   m_Layer: 13
   m_Name: Back_5
   m_TagString: Bone
@@ -1119,9 +1135,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5005036422705746442}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1131,9 +1147,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1158,10 +1174,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 5005036422705746442}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1170,9 +1186,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1318,6 +1334,20 @@ MonoBehaviour:
     m_Bits: 0
   storedPosition: {x: 0, y: 0, z: 0}
   storedRotation: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5005036422705746442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777015713573393535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &2168024215688232703
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,6 +1456,7 @@ GameObject:
   - component: {fileID: 18663942}
   - component: {fileID: 744659602}
   - component: {fileID: 744659603}
+  - component: {fileID: 4629295847757797393}
   m_Layer: 13
   m_Name: Back_1
   m_TagString: Bone
@@ -1702,9 +1733,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 4629295847757797393}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1714,9 +1745,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1741,9 +1772,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 4629295847757797393}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1753,9 +1784,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1813,6 +1844,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4629295847757797393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2322968982182209632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &3814371106168548784
 GameObject:
   m_ObjectHideFlags: 0
@@ -1953,6 +1998,7 @@ GameObject:
   - component: {fileID: 1043450806}
   - component: {fileID: 2001593012}
   - component: {fileID: 2001593013}
+  - component: {fileID: 5675051283087947917}
   m_Layer: 13
   m_Name: Head
   m_TagString: Bone
@@ -2160,9 +2206,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5675051283087947917}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2172,9 +2218,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2199,9 +2245,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5675051283087947917}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2211,9 +2257,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2340,6 +2386,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &5675051283087947917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4648646452388991490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &6048210018162169073
 GameObject:
   m_ObjectHideFlags: 0
@@ -2355,6 +2415,7 @@ GameObject:
   - component: {fileID: 5996645361607201537}
   - component: {fileID: 5996645361607201539}
   - component: {fileID: 5996645361607201540}
+  - component: {fileID: 2031851543283281003}
   m_Layer: 13
   m_Name: Back_2
   m_TagString: Bone
@@ -2631,9 +2692,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 2031851543283281003}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2643,9 +2704,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2670,9 +2731,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 2031851543283281003}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2682,9 +2743,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2742,6 +2803,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &2031851543283281003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6048210018162169073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &6623024931096006545
 GameObject:
   m_ObjectHideFlags: 0
@@ -2850,6 +2925,7 @@ GameObject:
   - component: {fileID: 1355815933}
   - component: {fileID: 1355815934}
   - component: {fileID: 1355815935}
+  - component: {fileID: 4328472244996981720}
   m_Layer: 13
   m_Name: Tail_end
   m_TagString: Bone
@@ -3124,9 +3200,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 4328472244996981720}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3136,9 +3212,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3163,10 +3239,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 4328472244996981720}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3175,9 +3251,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3235,6 +3311,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4328472244996981720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6748978213728608801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &6915616972181788328
 GameObject:
   m_ObjectHideFlags: 0
@@ -3249,6 +3339,7 @@ GameObject:
   - component: {fileID: 919132148199949408}
   - component: {fileID: 919132148199949410}
   - component: {fileID: 919132148199949411}
+  - component: {fileID: 6171414213059605995}
   m_Layer: 6
   m_Name: salmon_rigged_4lice_1gill
   m_TagString: Fish
@@ -3422,7 +3513,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _killPlane: -3
   _useStartPositionAsSpawnPosition: 0
-  _useSpawnObject: 0
   _spawnObject: {fileID: 0}
   _respawnPosition: {x: 0, y: 0, z: 0}
   _respawnRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -3466,6 +3556,35 @@ MonoBehaviour:
   startTank: {fileID: 0}
   endTank: {fileID: 0}
   sedationTimer: 3
+  m_OnFishCalmedDown:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnBroughtToTable:
+    m_PersistentCalls:
+      m_Calls: []
+  BringFishStepCompleted: 0
+  m_OnInspected:
+    m_PersistentCalls:
+      m_Calls: []
+  HasBeenInspected: 0
+  m_OnPlacedInRecoveryTank:
+    m_PersistentCalls:
+      m_Calls: []
+  PlacedInRecoveryTank: 0
+--- !u!114 &6171414213059605995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915616972181788328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee0474ab07aa154b9bf194a948b701f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Head: {fileID: 7589862318644897614}
+  Armature: {fileID: 3814371106168548784}
 --- !u!1 &7132867527503714408
 GameObject:
   m_ObjectHideFlags: 0
@@ -3481,6 +3600,7 @@ GameObject:
   - component: {fileID: 1253310518}
   - component: {fileID: 1253310519}
   - component: {fileID: 1253310520}
+  - component: {fileID: 2490393531267587702}
   m_Layer: 13
   m_Name: Back_4
   m_TagString: Bone
@@ -3688,9 +3808,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 2490393531267587702}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3700,9 +3820,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3727,10 +3847,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 2490393531267587702}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3739,9 +3859,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3868,6 +3988,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &2490393531267587702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132867527503714408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &7531260673488108337
 GameObject:
   m_ObjectHideFlags: 0
@@ -3883,6 +4017,7 @@ GameObject:
   - component: {fileID: 569489947}
   - component: {fileID: 1705924679}
   - component: {fileID: 1705924680}
+  - component: {fileID: 1562976255845079016}
   m_Layer: 13
   m_Name: Back_3
   m_TagString: Bone
@@ -4159,9 +4294,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1562976255845079016}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4171,9 +4306,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4198,10 +4333,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1562976255845079016}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4210,9 +4345,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4270,6 +4405,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1562976255845079016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7531260673488108337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}
 --- !u!1 &7852440317991942239
 GameObject:
   m_ObjectHideFlags: 0
@@ -4285,6 +4434,7 @@ GameObject:
   - component: {fileID: 415868202}
   - component: {fileID: 682472283}
   - component: {fileID: 682472284}
+  - component: {fileID: 1164565598265058144}
   m_Layer: 13
   m_Name: Tail
   m_TagString: Bone
@@ -4561,9 +4711,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1164565598265058144}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4573,9 +4723,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4600,10 +4750,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1164565598265058144}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4612,9 +4762,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6171414213059605995}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4672,3 +4822,17 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1164565598265058144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7852440317991942239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 6171414213059605995}

--- a/Assets/FishWelfare/Prefabs/salmon_rigged_4lice_4gill.prefab
+++ b/Assets/FishWelfare/Prefabs/salmon_rigged_4lice_4gill.prefab
@@ -529,6 +529,7 @@ GameObject:
   - component: {fileID: 752814164}
   - component: {fileID: 752814165}
   - component: {fileID: 1119661658}
+  - component: {fileID: 5357187087011962414}
   m_Layer: 13
   m_Name: Neck
   m_TagString: Bone
@@ -736,9 +737,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5357187087011962414}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -748,9 +749,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -775,9 +776,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5357187087011962414}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -787,9 +788,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -916,6 +917,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &5357187087011962414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 273438476667798305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &1777015713573393535
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,6 +946,7 @@ GameObject:
   - component: {fileID: 108685240}
   - component: {fileID: 117183120}
   - component: {fileID: 1171745047}
+  - component: {fileID: 7852493648451732771}
   m_Layer: 13
   m_Name: Back_5
   m_TagString: Bone
@@ -1119,9 +1135,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7852493648451732771}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1131,9 +1147,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1158,10 +1174,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 7852493648451732771}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1170,9 +1186,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1318,6 +1334,20 @@ MonoBehaviour:
     m_Bits: 0
   storedPosition: {x: 0, y: 0, z: 0}
   storedRotation: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &7852493648451732771
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777015713573393535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &2168024215688232703
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,6 +1456,7 @@ GameObject:
   - component: {fileID: 18663942}
   - component: {fileID: 744659602}
   - component: {fileID: 744659603}
+  - component: {fileID: 5771311670578819636}
   m_Layer: 13
   m_Name: Back_1
   m_TagString: Bone
@@ -1702,9 +1733,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5771311670578819636}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1714,9 +1745,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1741,9 +1772,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5771311670578819636}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1753,9 +1784,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1813,6 +1844,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &5771311670578819636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2322968982182209632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &3814371106168548784
 GameObject:
   m_ObjectHideFlags: 0
@@ -1953,6 +1998,7 @@ GameObject:
   - component: {fileID: 1043450806}
   - component: {fileID: 2001593012}
   - component: {fileID: 2001593013}
+  - component: {fileID: 868940232456030460}
   m_Layer: 13
   m_Name: Head
   m_TagString: Bone
@@ -2160,9 +2206,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 868940232456030460}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2172,9 +2218,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2199,9 +2245,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 868940232456030460}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2211,9 +2257,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2340,6 +2386,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &868940232456030460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4648646452388991490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &6048210018162169073
 GameObject:
   m_ObjectHideFlags: 0
@@ -2355,6 +2415,7 @@ GameObject:
   - component: {fileID: 5996645361607201537}
   - component: {fileID: 5996645361607201539}
   - component: {fileID: 5996645361607201540}
+  - component: {fileID: 8238836656026239747}
   m_Layer: 13
   m_Name: Back_2
   m_TagString: Bone
@@ -2631,9 +2692,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8238836656026239747}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2643,9 +2704,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2670,9 +2731,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8238836656026239747}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2682,9 +2743,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2742,6 +2803,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &8238836656026239747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6048210018162169073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &6623024931096006545
 GameObject:
   m_ObjectHideFlags: 0
@@ -2850,6 +2925,7 @@ GameObject:
   - component: {fileID: 1355815933}
   - component: {fileID: 1355815934}
   - component: {fileID: 1355815935}
+  - component: {fileID: 8549790189056242698}
   m_Layer: 13
   m_Name: Tail_end
   m_TagString: Bone
@@ -3124,9 +3200,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8549790189056242698}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3136,9 +3212,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3163,10 +3239,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 8549790189056242698}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3175,9 +3251,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3235,6 +3311,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &8549790189056242698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6748978213728608801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &6915616972181788328
 GameObject:
   m_ObjectHideFlags: 0
@@ -3249,6 +3339,7 @@ GameObject:
   - component: {fileID: 919132148199949408}
   - component: {fileID: 919132148199949410}
   - component: {fileID: 919132148199949411}
+  - component: {fileID: 7440065427075290398}
   m_Layer: 6
   m_Name: salmon_rigged_4lice_4gill
   m_TagString: Fish
@@ -3422,7 +3513,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _killPlane: -3
   _useStartPositionAsSpawnPosition: 0
-  _useSpawnObject: 0
   _spawnObject: {fileID: 0}
   _respawnPosition: {x: 0, y: 0, z: 0}
   _respawnRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -3466,6 +3556,35 @@ MonoBehaviour:
   startTank: {fileID: 0}
   endTank: {fileID: 0}
   sedationTimer: 3
+  m_OnFishCalmedDown:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnBroughtToTable:
+    m_PersistentCalls:
+      m_Calls: []
+  BringFishStepCompleted: 0
+  m_OnInspected:
+    m_PersistentCalls:
+      m_Calls: []
+  HasBeenInspected: 0
+  m_OnPlacedInRecoveryTank:
+    m_PersistentCalls:
+      m_Calls: []
+  PlacedInRecoveryTank: 0
+--- !u!114 &7440065427075290398
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915616972181788328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee0474ab07aa154b9bf194a948b701f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Head: {fileID: 7589862318644897614}
+  Armature: {fileID: 3814371106168548784}
 --- !u!1 &7132867527503714408
 GameObject:
   m_ObjectHideFlags: 0
@@ -3481,6 +3600,7 @@ GameObject:
   - component: {fileID: 1253310518}
   - component: {fileID: 1253310519}
   - component: {fileID: 1253310520}
+  - component: {fileID: 1193038398846221907}
   m_Layer: 13
   m_Name: Back_4
   m_TagString: Bone
@@ -3688,9 +3808,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1193038398846221907}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3700,9 +3820,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3727,10 +3847,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1193038398846221907}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3739,9 +3859,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3868,6 +3988,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &1193038398846221907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132867527503714408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &7531260673488108337
 GameObject:
   m_ObjectHideFlags: 0
@@ -3883,6 +4017,7 @@ GameObject:
   - component: {fileID: 569489947}
   - component: {fileID: 1705924679}
   - component: {fileID: 1705924680}
+  - component: {fileID: 8798639754536647256}
   m_Layer: 13
   m_Name: Back_3
   m_TagString: Bone
@@ -4159,9 +4294,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8798639754536647256}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4171,9 +4306,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4198,10 +4333,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 8798639754536647256}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4210,9 +4345,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4270,6 +4405,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &8798639754536647256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7531260673488108337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}
 --- !u!1 &7852440317991942239
 GameObject:
   m_ObjectHideFlags: 0
@@ -4285,6 +4434,7 @@ GameObject:
   - component: {fileID: 415868202}
   - component: {fileID: 682472283}
   - component: {fileID: 682472284}
+  - component: {fileID: 1198208124431107089}
   m_Layer: 13
   m_Name: Tail
   m_TagString: Bone
@@ -4561,9 +4711,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1198208124431107089}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4573,9 +4723,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4600,10 +4750,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1198208124431107089}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4612,9 +4762,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7440065427075290398}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4672,3 +4822,17 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1198208124431107089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7852440317991942239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7440065427075290398}

--- a/Assets/FishWelfare/Prefabs/salmon_rigged_5lice_5gill.prefab
+++ b/Assets/FishWelfare/Prefabs/salmon_rigged_5lice_5gill.prefab
@@ -529,6 +529,7 @@ GameObject:
   - component: {fileID: 752814164}
   - component: {fileID: 752814165}
   - component: {fileID: 1119661658}
+  - component: {fileID: 8946946167891924726}
   m_Layer: 13
   m_Name: Neck
   m_TagString: Bone
@@ -736,9 +737,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8946946167891924726}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -748,9 +749,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -775,9 +776,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 8946946167891924726}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -787,9 +788,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -916,6 +917,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &8946946167891924726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 273438476667798305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &1777015713573393535
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,6 +946,7 @@ GameObject:
   - component: {fileID: 108685240}
   - component: {fileID: 117183120}
   - component: {fileID: 1171745047}
+  - component: {fileID: 5129246938208274446}
   m_Layer: 13
   m_Name: Back_5
   m_TagString: Bone
@@ -1119,9 +1135,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5129246938208274446}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1131,9 +1147,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1158,10 +1174,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 5129246938208274446}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1170,9 +1186,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1318,6 +1334,20 @@ MonoBehaviour:
     m_Bits: 0
   storedPosition: {x: 0, y: 0, z: 0}
   storedRotation: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5129246938208274446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777015713573393535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &2168024215688232703
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,6 +1456,7 @@ GameObject:
   - component: {fileID: 18663942}
   - component: {fileID: 744659602}
   - component: {fileID: 744659603}
+  - component: {fileID: 1133001352416914589}
   m_Layer: 13
   m_Name: Back_1
   m_TagString: Bone
@@ -1702,9 +1733,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1133001352416914589}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1714,9 +1745,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1741,9 +1772,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1133001352416914589}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1753,9 +1784,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1813,6 +1844,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1133001352416914589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2322968982182209632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &3814371106168548784
 GameObject:
   m_ObjectHideFlags: 0
@@ -1953,6 +1998,7 @@ GameObject:
   - component: {fileID: 1043450806}
   - component: {fileID: 2001593012}
   - component: {fileID: 2001593013}
+  - component: {fileID: 5258179466146145757}
   m_Layer: 13
   m_Name: Head
   m_TagString: Bone
@@ -2160,9 +2206,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5258179466146145757}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2172,9 +2218,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2199,9 +2245,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5258179466146145757}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2211,9 +2257,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2340,6 +2386,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &5258179466146145757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4648646452388991490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &6048210018162169073
 GameObject:
   m_ObjectHideFlags: 0
@@ -2355,6 +2415,7 @@ GameObject:
   - component: {fileID: 5996645361607201537}
   - component: {fileID: 5996645361607201539}
   - component: {fileID: 5996645361607201540}
+  - component: {fileID: 1712397883801900773}
   m_Layer: 13
   m_Name: Back_2
   m_TagString: Bone
@@ -2631,9 +2692,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1712397883801900773}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2643,9 +2704,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2670,9 +2731,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1712397883801900773}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2682,9 +2743,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2742,6 +2803,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1712397883801900773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6048210018162169073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &6623024931096006545
 GameObject:
   m_ObjectHideFlags: 0
@@ -2850,6 +2925,7 @@ GameObject:
   - component: {fileID: 1355815933}
   - component: {fileID: 1355815934}
   - component: {fileID: 1355815935}
+  - component: {fileID: 1154181825534061111}
   m_Layer: 13
   m_Name: Tail_end
   m_TagString: Bone
@@ -3124,9 +3200,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1154181825534061111}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3136,9 +3212,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3163,10 +3239,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1154181825534061111}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3175,9 +3251,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3235,6 +3311,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1154181825534061111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6748978213728608801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &6915616972181788328
 GameObject:
   m_ObjectHideFlags: 0
@@ -3249,6 +3339,7 @@ GameObject:
   - component: {fileID: 919132148199949408}
   - component: {fileID: 919132148199949410}
   - component: {fileID: 919132148199949411}
+  - component: {fileID: 7760654178898874432}
   m_Layer: 6
   m_Name: salmon_rigged_5lice_5gill
   m_TagString: Fish
@@ -3422,7 +3513,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _killPlane: -3
   _useStartPositionAsSpawnPosition: 0
-  _useSpawnObject: 0
   _spawnObject: {fileID: 0}
   _respawnPosition: {x: 0, y: 0, z: 0}
   _respawnRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -3466,6 +3556,35 @@ MonoBehaviour:
   startTank: {fileID: 0}
   endTank: {fileID: 0}
   sedationTimer: 3
+  m_OnFishCalmedDown:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnBroughtToTable:
+    m_PersistentCalls:
+      m_Calls: []
+  BringFishStepCompleted: 0
+  m_OnInspected:
+    m_PersistentCalls:
+      m_Calls: []
+  HasBeenInspected: 0
+  m_OnPlacedInRecoveryTank:
+    m_PersistentCalls:
+      m_Calls: []
+  PlacedInRecoveryTank: 0
+--- !u!114 &7760654178898874432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915616972181788328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee0474ab07aa154b9bf194a948b701f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Head: {fileID: 7589862318644897614}
+  Armature: {fileID: 3814371106168548784}
 --- !u!1 &7132867527503714408
 GameObject:
   m_ObjectHideFlags: 0
@@ -3481,6 +3600,7 @@ GameObject:
   - component: {fileID: 1253310518}
   - component: {fileID: 1253310519}
   - component: {fileID: 1253310520}
+  - component: {fileID: 6151633477311912446}
   m_Layer: 13
   m_Name: Back_4
   m_TagString: Bone
@@ -3688,9 +3808,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 6151633477311912446}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3700,9 +3820,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3727,10 +3847,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 6151633477311912446}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3739,9 +3859,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3868,6 +3988,20 @@ MonoBehaviour:
   UseCustomInspector: 1
   lastFlickTime: 0
   FlickForce: 1
+--- !u!114 &6151633477311912446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132867527503714408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &7531260673488108337
 GameObject:
   m_ObjectHideFlags: 0
@@ -3883,6 +4017,7 @@ GameObject:
   - component: {fileID: 569489947}
   - component: {fileID: 1705924679}
   - component: {fileID: 1705924680}
+  - component: {fileID: 4327431415643873513}
   m_Layer: 13
   m_Name: Back_3
   m_TagString: Bone
@@ -4159,9 +4294,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 4327431415643873513}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4171,9 +4306,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4198,10 +4333,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 4327431415643873513}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4210,9 +4345,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4270,6 +4405,20 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4327431415643873513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7531260673488108337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}
 --- !u!1 &7852440317991942239
 GameObject:
   m_ObjectHideFlags: 0
@@ -4285,6 +4434,7 @@ GameObject:
   - component: {fileID: 415868202}
   - component: {fileID: 682472283}
   - component: {fileID: 682472284}
+  - component: {fileID: 3973910085959108888}
   m_Layer: 13
   m_Name: Tail
   m_TagString: Bone
@@ -4561,9 +4711,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3973910085959108888}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4573,9 +4723,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4600,10 +4750,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 3973910085959108888}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4612,9 +4762,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7760654178898874432}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4672,3 +4822,17 @@ MonoBehaviour:
   onSnapZoneExit:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &3973910085959108888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7852440317991942239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7760654178898874432}

--- a/Assets/FishWelfare/Scenes/FishWelfare.unity
+++ b/Assets/FishWelfare/Scenes/FishWelfare.unity
@@ -5058,6 +5058,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 5175200028539421316, guid: bf00b0ab64967b749a29ac9e127969d7,
+        type: 3}
+      propertyPath: _audioManager
+      value: 
+      objectReference: {fileID: 768784524}
     - target: {fileID: 5175200028539421317, guid: bf00b0ab64967b749a29ac9e127969d7,
         type: 3}
       propertyPath: m_RootOrder
@@ -5350,6 +5355,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &768784524 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5582427761267303759, guid: aabd3c08d3b33f54dafb54f8da691fd9,
+    type: 3}
+  m_PrefabInstance: {fileID: 2125031667}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &780493161
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Fish/LaboratoryFish.prefab
+++ b/Assets/Laboratory/Prefabs/Fish/LaboratoryFish.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 7083632345898002462}
   - component: {fileID: 7083632345898002449}
   - component: {fileID: 4057657869050500088}
+  - component: {fileID: 5285401525055578250}
   m_Layer: 13
   m_Name: Back_4
   m_TagString: Bone
@@ -203,9 +204,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5285401525055578250}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -215,9 +216,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -242,10 +243,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 5285401525055578250}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -254,9 +255,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -408,6 +409,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &5285401525055578250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 50409512750067777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &777565521727132440
 GameObject:
   m_ObjectHideFlags: 0
@@ -425,6 +440,7 @@ GameObject:
   - component: {fileID: 7083632346685894753}
   - component: {fileID: 777565521727132446}
   - component: {fileID: 3928845680366324634}
+  - component: {fileID: 1664693956035173987}
   m_Layer: 13
   m_Name: Back_3
   m_TagString: Bone
@@ -702,9 +718,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 1664693956035173987}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -714,9 +730,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -741,10 +757,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 1664693956035173987}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -753,9 +769,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -852,6 +868,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &1664693956035173987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 777565521727132440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &1060429262418268278
 GameObject:
   m_ObjectHideFlags: 0
@@ -867,6 +897,7 @@ GameObject:
   - component: {fileID: 7083632347274939651}
   - component: {fileID: 7083632347541543797}
   - component: {fileID: 3465442343043002778}
+  - component: {fileID: 3517894392848555631}
   m_Layer: 13
   m_Name: Tail
   m_TagString: Bone
@@ -1124,9 +1155,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3517894392848555631}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1136,9 +1167,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1163,10 +1194,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 3517894392848555631}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1175,9 +1206,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1260,6 +1291,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &3517894392848555631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1060429262418268278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &1668762624083483057
 GameObject:
   m_ObjectHideFlags: 0
@@ -1373,6 +1418,7 @@ GameObject:
   - component: {fileID: 7083632346914507421}
   - component: {fileID: 7083632346914507420}
   - component: {fileID: 4649741961462264624}
+  - component: {fileID: 3065866387328678212}
   m_Layer: 13
   m_Name: Head
   m_TagString: Bone
@@ -1563,9 +1609,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3065866387328678212}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1575,9 +1621,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1602,9 +1648,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3065866387328678212}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1614,9 +1660,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1768,6 +1814,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &3065866387328678212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2507749934695266859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &3576298878128913624
 GameObject:
   m_ObjectHideFlags: 0
@@ -1783,6 +1843,7 @@ GameObject:
   - component: {fileID: 3564110069426879272}
   - component: {fileID: 3564110069426879277}
   - component: {fileID: 6129345640710118151}
+  - component: {fileID: 3414960909139330881}
   m_Layer: 13
   m_Name: Back_2
   m_TagString: Bone
@@ -2040,9 +2101,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3414960909139330881}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2052,9 +2113,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2079,9 +2140,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 3414960909139330881}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2091,9 +2152,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2176,6 +2237,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &3414960909139330881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3576298878128913624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &4154473913965553592
 GameObject:
   m_ObjectHideFlags: 0
@@ -2281,6 +2356,7 @@ GameObject:
   - component: {fileID: 7966717964052999286}
   - component: {fileID: 7966717964052999240}
   - component: {fileID: 7966717964052999241}
+  - component: {fileID: 7497299651652543705}
   m_Layer: 6
   m_Name: LaboratoryFish
   m_TagString: Fish
@@ -2440,6 +2516,21 @@ MonoBehaviour:
   - m_Rig: {fileID: 7083632346519321991}
     m_Active: 1
   m_Effectors: []
+--- !u!114 &7497299651652543705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4447070333770235521}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee0474ab07aa154b9bf194a948b701f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Head: {fileID: 800098695171280743}
+  Armature: {fileID: 6242341309553771929}
+  StretchLimit: 0.15
 --- !u!1 &4604704099326708232
 GameObject:
   m_ObjectHideFlags: 0
@@ -2455,6 +2546,7 @@ GameObject:
   - component: {fileID: 7083632346336048084}
   - component: {fileID: 7083632346336048086}
   - component: {fileID: 2576527459034082799}
+  - component: {fileID: 123591896907928815}
   m_Layer: 13
   m_Name: Tail_end
   m_TagString: Bone
@@ -2710,9 +2802,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 123591896907928815}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2722,9 +2814,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2749,10 +2841,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 123591896907928815}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -2761,9 +2853,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2846,6 +2938,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &123591896907928815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4604704099326708232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &4788111375827927113
 GameObject:
   m_ObjectHideFlags: 0
@@ -2861,6 +2967,7 @@ GameObject:
   - component: {fileID: 7083632347146314287}
   - component: {fileID: 7083632347603612346}
   - component: {fileID: 9205257394693750304}
+  - component: {fileID: 7227867956189191496}
   m_Layer: 13
   m_Name: Back_1
   m_TagString: Bone
@@ -3118,9 +3225,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7227867956189191496}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3130,9 +3237,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3157,9 +3264,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7227867956189191496}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3169,9 +3276,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3254,6 +3361,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &7227867956189191496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4788111375827927113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &6242341309553771929
 GameObject:
   m_ObjectHideFlags: 0
@@ -3394,6 +3515,7 @@ GameObject:
   - component: {fileID: 7083632347611701372}
   - component: {fileID: 7083632346032703091}
   - component: {fileID: 5166986676011857401}
+  - component: {fileID: 7468815914408935041}
   m_Layer: 13
   m_Name: Neck
   m_TagString: Bone
@@ -3582,9 +3704,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7468815914408935041}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3594,9 +3716,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3621,9 +3743,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7468815914408935041}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3633,9 +3755,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3787,6 +3909,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &7468815914408935041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027142426937977608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &7083632345953085967
 GameObject:
   m_ObjectHideFlags: 0
@@ -4316,6 +4452,7 @@ GameObject:
   - component: {fileID: 7083632347169017745}
   - component: {fileID: 7083632347177794233}
   - component: {fileID: 7372510267639292045}
+  - component: {fileID: 5336783007630722233}
   m_Layer: 13
   m_Name: Back_5
   m_TagString: Bone
@@ -4504,9 +4641,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 5336783007630722233}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: SetGrabbedJoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4516,9 +4653,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: IncrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4543,10 +4680,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Bone, Assembly-CSharp
-        m_MethodName: 
-        m_Mode: 6
+      - m_Target: {fileID: 5336783007630722233}
+        m_TargetAssemblyTypeName: WhichJointGrabbed, Assembly-CSharp
+        m_MethodName: UnsetGrabbedJoint
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -4555,9 +4692,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RatingInterfaceController, Assembly-CSharp
-        m_MethodName: SeteActive
+      - m_Target: {fileID: 7497299651652543705}
+        m_TargetAssemblyTypeName: DropWhenStretched, Assembly-CSharp
+        m_MethodName: DecrementGrabCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4709,6 +4846,20 @@ MonoBehaviour:
   B: 0
   TriggerFrontRight: 0
   TriggerGripRight: 1
+--- !u!114 &5336783007630722233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8856087283986070614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6005cf213e1f0a42b4de7e0146275ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Grabbed: 0
+  DropWhenStretchedScript: {fileID: 7497299651652543705}
 --- !u!1 &8915334578607685342
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug fix, improvement.

* **What is the current behavior?**
The anti-stretch mechanisms introduced in #562 relies on Unity Events on a separate object in the scenes as a work around for not having access to BNG's namespace in code. This breaks very easily, and the anti-stretch mechanisms therefore do not work currently. The anti-stretch code should be refactored and simplified so it does not break so easily #766.  

* **What is the new behavior?**
Anti-stretch scripts directly access BNG-related information, and thus no longer need work arounds. The anti-stretch mechanism is introduced in all scenes containing rag-doll fishes. The "DropObject" prefab is removed from all scenes because it is no longer needed.

* **Does this PR introduce a breaking change?**
No