### PR TITLE
Ability to deactivate tooltips with tag

### DIFF
--- a/Assets/FishFactory/Scenes/HSERoom.unity
+++ b/Assets/FishFactory/Scenes/HSERoom.unity
@@ -19998,6 +19998,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: SteelGlove
       objectReference: {fileID: 0}
+    - target: {fileID: 9180268195025381912, guid: 5933e4e08e3fd6d4c99460b5bc91068e,
+        type: 3}
+      propertyPath: m_TagString
+      value: ControllerTooltipDeactivator
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 779834275297923021, guid: 5933e4e08e3fd6d4c99460b5bc91068e, type: 3}
     - {fileID: 8333828205353949104, guid: 5933e4e08e3fd6d4c99460b5bc91068e, type: 3}
@@ -35768,6 +35773,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: BlueGlove
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180268195025381912, guid: 5933e4e08e3fd6d4c99460b5bc91068e,
+        type: 3}
+      propertyPath: m_TagString
+      value: ControllerTooltipDeactivator
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 779834275297923021, guid: 5933e4e08e3fd6d4c99460b5bc91068e, type: 3}

--- a/Assets/VR4VET/Components/ControllerToolTips/Scripts/ControllerTooltipManager.cs
+++ b/Assets/VR4VET/Components/ControllerToolTips/Scripts/ControllerTooltipManager.cs
@@ -95,21 +95,30 @@ public class ControllerTooltipManager : MonoBehaviour
         {
             if (_accessibilityEnabled)
             {
+                bool deactivated = false;
+
                 Collider[] surroundingColliders = new Collider[8];
                 Physics.OverlapSphereNonAlloc(controllerModel.transform.position, .1f, surroundingColliders);
 
                 List<ControllerTooltipActivator> activators = new();
                 foreach (Collider surroundingCollider in surroundingColliders)
                 {
-                    if (surroundingCollider && surroundingCollider.GetComponentInChildren<ControllerTooltipActivator>())
+                    if (surroundingCollider && surroundingCollider.CompareTag("ControllerTooltipDeactivator")) // hand intersects with a deactivator, prepare to deactivate all tooltips
+                    {
+                        activators.Clear();
+                        deactivated = true;
+                        break;
+                    }
+
+                    if (surroundingCollider && surroundingCollider.GetComponentInChildren<ControllerTooltipActivator>()) // add all activators to list
                         activators.Add(surroundingCollider.GetComponentInChildren<ControllerTooltipActivator>());
                 }
 
-                if (activators.Count > 0)
+                if (activators.Count > 0) // there are activators in player hand's vicinity
                 {
                     float shortestDistance = Mathf.Infinity;
                     ControllerTooltipActivator closestActivator = activators[0];
-                    foreach (ControllerTooltipActivator activator in activators)
+                    foreach (ControllerTooltipActivator activator in activators) // find closest activator
                     {
                         if (Vector3.Distance(controllerModel.transform.position, activator.transform.position) < shortestDistance)
                         {
@@ -118,7 +127,7 @@ public class ControllerTooltipManager : MonoBehaviour
                         }
                     }
 
-                    if (TooltippedButtonsDown(closestActivator, controllerHand))
+                    if (TooltippedButtonsDown(closestActivator, controllerHand)) // close tooltips if player is pressing the correct buttons
                         CloseAllTooltips(controllerHand);
                     else
                     {
@@ -130,7 +139,7 @@ public class ControllerTooltipManager : MonoBehaviour
                 }
                 else
                 {
-                    if (controllerHand != ControllerHand.Left)
+                    if (deactivated || controllerHand != ControllerHand.Left)
                         CloseAllTooltips(controllerHand);
                     else
                     {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -45,6 +45,7 @@ TagManager:
   - Merd
   - Tablet
   - SortingSquare
+  - ControllerTooltipDeactivator
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature, improvement

* **What is the current behavior?**
There is no way to easily make objects deactivate a hand's controller tooltips (#767). This is a problem because certain controller tooltips are always active, preventing the player from seeing their own hands. An example of this behaviour being problematic is when equipping the safety gloves in the HSE room. The player can not see that their left hand glove has changed. 

* **What is the new behavior?** (if this is a feature change)
Giving objects the tag "ControllerTooltipDeactivator" makes them deactivate hand controller tooltips when nearby. This is change can be seen in the HSE room scene.

* **Does this PR introduce a breaking change?**
No, but the Tag Manager and the HSE Room scene are changed.