### PR TITLE
72 fps in Lab Scenario and higher contrast mode for more UI elements

### DIFF
--- a/Assets/ContrastModifier.cs
+++ b/Assets/ContrastModifier.cs
@@ -1,3 +1,4 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -22,6 +23,7 @@ public class ContrastModifier : MonoBehaviour
     private Color _contrastTranslucentBackground;
 
     private bool _highContrastMode;
+    private bool _settingLoaded = false;
 
     private NewMenuManger MainMenu;
 
@@ -70,6 +72,8 @@ public class ContrastModifier : MonoBehaviour
 
     public void ToggleContrast(bool contrast)
     {
+        _settingLoaded = true;
+        Debug.Log("Toggled with value " + contrast);
         _highContrastMode = contrast;
         if (_highContrastMode)
         {
@@ -131,5 +135,9 @@ public class ContrastModifier : MonoBehaviour
         }
     }
 
-    private void OnUIChanged() => ToggleContrast(_highContrastMode);
+    private void OnUIChanged()
+    { 
+        if (_settingLoaded)
+            ToggleContrast(_highContrastMode); 
+    } 
 }

--- a/Assets/ContrastModifier.cs
+++ b/Assets/ContrastModifier.cs
@@ -75,7 +75,7 @@ public class ContrastModifier : MonoBehaviour
     public void ToggleContrast(bool contrast)
     {
         _settingLoaded = true;
-        Debug.Log("Toggled with value " + contrast);
+        //Debug.Log("Toggled with value " + contrast);
         _highContrastMode = contrast;
         if (_highContrastMode)
         {

--- a/Assets/ContrastModifier.cs
+++ b/Assets/ContrastModifier.cs
@@ -1,4 +1,4 @@
-using TMPro;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -10,8 +10,8 @@ public class ContrastModifier : MonoBehaviour
     private Color _defaultBackground = new Color32(0xF2, 0xF7, 0xFF, 0xFF);
     private Color _defaultPositive = new Color32(0x1C, 0xA3, 0x8C, 0xFF);
     private Color _defaultBrandPurple = new Color32(0x8A, 0x99, 0xFA, 0xFF);
-    private Color _defaultRed = new Color32(0xE5, 0x14, 0x45, 0xFF); //E51445
-    private Color _defaultTranslucentBackground = new Color32(0xDF, 0xE9, 0xF7, 50); // DFE9F7
+    private Color _defaultRed = new Color32(0xE5, 0x14, 0x45, 0xFF);
+    private Color _defaultTranslucentBackground = new Color32(0xDF, 0xE9, 0xF7, 50);
     private Color _contrastDarkBlue;
     private Color _contrastLightBlue;
     private Color _contrastMiddleBlue;
@@ -24,6 +24,8 @@ public class ContrastModifier : MonoBehaviour
 
     private bool _highContrastMode;
     private bool _settingLoaded = false;
+
+    [SerializeField] private List<GameObject> ExcludeObjects;
 
     private NewMenuManger MainMenu;
 
@@ -79,6 +81,9 @@ public class ContrastModifier : MonoBehaviour
         {
             foreach (Image image in transform.GetComponentsInChildren<Image>(true))
             {
+                if (ExcludeObjects.Contains(image.gameObject))
+                    continue;
+
                 if (image.color == _defaultDarkBlue)
                     image.color = _contrastDarkBlue;
 
@@ -108,6 +113,9 @@ public class ContrastModifier : MonoBehaviour
         {
             foreach (Image image in transform.GetComponentsInChildren<Image>(true))
             {
+                if (ExcludeObjects.Contains(image.gameObject))
+                    continue;
+
                 if (image.color == _contrastDarkBlue)
                     image.color = _defaultDarkBlue;
 

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Icons/Button_Wide_VeryTall.png
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Icons/Button_Wide_VeryTall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec690bf6f90a25f7b34608878f5f5e4a0eb51c0835978d4c045096c659fb6206
+size 4807

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Icons/Button_Wide_VeryTall.png.meta
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Icons/Button_Wide_VeryTall.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da07fcfe547d0984c87a8fcbf8b4e2a6
+guid: 214273148a9367f498d4b7d770ebf965
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/FloatingUIElement.cs
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/FloatingUIElement.cs
@@ -1,16 +1,17 @@
 using System;
 using UnityEngine;
-using UnityEngine.Events;
+using UnityEngine.UI;
 
 public class FloatingUIElement : MonoBehaviour
 {
-    private RectTransform rectTransform;
-    private bool isScaling, scalingUp = false;
-    private Canvas canvas;
+    private RectTransform _rectTransform;
+    private bool _isScaling, _scalingUp = false;
+    private float _enableTime;
+    private Button _button;
     [SerializeField] private Vector3 closedPosition, openPosition;
     [SerializeField] private float closedScale, openScale;
     [SerializeField] private StartState startState;
-    [SerializeField] private bool hideWhenClosed = false;
+    [SerializeField] float closeAutomaticallyAfterSeconds;
     [SerializeField] private Canvas canvasToHideWhenClosed;
     private enum StartState
     {
@@ -21,24 +22,25 @@ public class FloatingUIElement : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        rectTransform = GetComponent<RectTransform>();
-        Debug.Log(this.name + " " + rectTransform.localPosition);
-
-        if (hideWhenClosed)
-            canvasToHideWhenClosed.enabled = false;
+        _rectTransform = GetComponent<RectTransform>();
+        _button = GetComponent<Button>();
 
         // initiate in closed or open position
         if (startState == StartState.Closed)
         {
-            rectTransform.localScale = Vector3.one * closedScale;
-            //rectTransform.localPosition = closedPosition;
-            rectTransform.anchoredPosition = closedPosition;
+            _rectTransform.localScale = Vector3.one * closedScale;
+            _rectTransform.anchoredPosition = closedPosition;
+
+            if (canvasToHideWhenClosed)
+                canvasToHideWhenClosed.enabled = false;
         }
         else
         {
-            rectTransform.localScale = Vector3.one * openScale;
-            rectTransform.anchoredPosition = openPosition;
+            _rectTransform.localScale = Vector3.one * openScale;
+            _rectTransform.anchoredPosition = openPosition;
 
+            if (canvasToHideWhenClosed)
+                canvasToHideWhenClosed.enabled = true;
         }
     }
 
@@ -54,45 +56,58 @@ public class FloatingUIElement : MonoBehaviour
             ToggleOnOff();*/
 
         // perform the opening/closing of canvas
-        if (isScaling)
+        if (_isScaling)
         {
-            if (scalingUp)
+            if (_scalingUp)
             {
-                if ((float)Math.Truncate(rectTransform.localScale.x * 1000) / 1000 == openScale - 0.001) // check first 3 decimals to prevent excessive precision/time spent scaling. subtraction prevents infinite interpolation
-                    isScaling = false;
-
-                float newScale = Mathf.Lerp(rectTransform.localScale.x, openScale, 6f * Time.deltaTime);
-                float newPositionX = Mathf.Lerp(rectTransform.anchoredPosition.x, openPosition.x, 6f * Time.deltaTime);
-                float newPositionY = Mathf.Lerp(rectTransform.anchoredPosition.y, openPosition.y, 6f * Time.deltaTime);
-                float newPositionZ = Mathf.Lerp(rectTransform.localPosition.z, openPosition.z, 6f * Time.deltaTime);
-                rectTransform.localScale = Vector3.one * newScale;
-                rectTransform.anchoredPosition = new Vector3(newPositionX, newPositionY);
-                rectTransform.localPosition += Vector3.forward * newPositionZ;
-            }
-            if (!scalingUp)
-            {
-                if ((float)Math.Truncate(rectTransform.localScale.x * 1000) / 1000 ==  closedScale + 0.001 /*(float)Math.Truncate(rectTransform.localScale.x * 100) / 100 == 0*/)
+                if ((float)Math.Truncate((openScale - _rectTransform.localScale.x) * 1000) / 1000 <= 0.001) // check first 3 decimals to prevent excessive precision/time spent scaling. subtraction prevents infinite interpolation
                 {
-                    isScaling = false;
+                    _isScaling = false;
+                    _button.interactable = false;
+                    _button.interactable = true;
+                }
+
+                float newScale = Mathf.Lerp(_rectTransform.localScale.x, openScale, 6f * Time.deltaTime);
+                float newPositionX = Mathf.Lerp(_rectTransform.anchoredPosition.x, openPosition.x, 6f * Time.deltaTime);
+                float newPositionY = Mathf.Lerp(_rectTransform.anchoredPosition.y, openPosition.y, 6f * Time.deltaTime);
+                float newPositionZ = Mathf.Lerp(_rectTransform.localPosition.z, openPosition.z, 6f * Time.deltaTime);
+                _rectTransform.localScale = Vector3.one * newScale;
+                _rectTransform.anchoredPosition = new Vector3(newPositionX, newPositionY);
+                _rectTransform.localPosition += Vector3.forward * newPositionZ;
+            }
+            if (!_scalingUp)
+            {
+                if ((float)Math.Truncate((_rectTransform.localScale.x - closedScale) * 1000) / 1000 <= 0.001)
+                {
+                    _isScaling = false;
+                    _button.interactable = false;
+                    _button.interactable = true;
                     
-                    if (hideWhenClosed)
+                    if (canvasToHideWhenClosed)
                         canvasToHideWhenClosed.enabled = false; 
                 }
 
-                float newScale = Mathf.Lerp(rectTransform.localScale.x, closedScale, 6f * Time.deltaTime);
-                float newPositionX = Mathf.Lerp(rectTransform.anchoredPosition.x, closedPosition.x, 6f * Time.deltaTime);
-                float newPositionY = Mathf.Lerp(rectTransform.anchoredPosition.y, closedPosition.y, 6f * Time.deltaTime);
-                float newPositionZ = Mathf.Lerp(rectTransform.localPosition.z, closedPosition.z, 6f * Time.deltaTime);
-                rectTransform.localScale = Vector3.one * newScale;
-                rectTransform.anchoredPosition = new Vector3(newPositionX, newPositionY);
-                rectTransform.localPosition += Vector3.forward * newPositionZ;
+                float newScale = Mathf.Lerp(_rectTransform.localScale.x, closedScale, 6f * Time.deltaTime);
+                float newPositionX = Mathf.Lerp(_rectTransform.anchoredPosition.x, closedPosition.x, 6f * Time.deltaTime);
+                float newPositionY = Mathf.Lerp(_rectTransform.anchoredPosition.y, closedPosition.y, 6f * Time.deltaTime);
+                float newPositionZ = Mathf.Lerp(_rectTransform.localPosition.z, closedPosition.z, 6f * Time.deltaTime);
+                _rectTransform.localScale = Vector3.one * newScale;
+                _rectTransform.anchoredPosition = new Vector3(newPositionX, newPositionY);
+                _rectTransform.localPosition += Vector3.forward * newPositionZ;
             }
+        }
+
+        // automatically close after provided time in seconds has passed
+        if (closeAutomaticallyAfterSeconds > 0 && _scalingUp)
+        {
+            if (Time.time - _enableTime > closeAutomaticallyAfterSeconds)
+                DisableAndScaleDown();
         }
     }
 
     public void ToggleOnOff()
     {
-        if (scalingUp)
+        if (_scalingUp)
             DisableAndScaleDown();
         else
             EnableAndScaleUp();
@@ -100,17 +115,19 @@ public class FloatingUIElement : MonoBehaviour
 
     public void EnableAndScaleUp()
     {
-        if (hideWhenClosed)
+        _enableTime = Time.time;
+
+        if (canvasToHideWhenClosed)
             canvasToHideWhenClosed.enabled = true;
         
-        scalingUp = true;
-        isScaling = true;
+        _scalingUp = true;
+        _isScaling = true;
     }
 
     public void DisableAndScaleDown()
     {
-        scalingUp = false;
-        isScaling = true;
+        _scalingUp = false;
+        _isScaling = true;
     }
 
     public bool IsEnabled()

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/FloatingUIElement.cs
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/FloatingUIElement.cs
@@ -11,7 +11,7 @@ public class FloatingUIElement : MonoBehaviour
     [SerializeField] private Vector3 closedPosition, openPosition;
     [SerializeField] private float closedScale, openScale;
     [SerializeField] private StartState startState;
-    [SerializeField] float closeAutomaticallyAfterSeconds;
+    [SerializeField] private float closeAutomaticallyAfterSeconds;
     [SerializeField] private Canvas canvasToHideWhenClosed;
     private enum StartState
     {

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/MicroscopeNumPad.cs
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/MicroscopeNumPad.cs
@@ -18,7 +18,6 @@ public class MicroscopeNumPad : MonoBehaviour
             {
                 RemoveCurrentInputField();
             }
-                //RemoveIndicator();
 
             currentInputField = value;
             StartIndicatorCycle();
@@ -26,7 +25,6 @@ public class MicroscopeNumPad : MonoBehaviour
     }
 
     private bool IndicatedLast = false;
-    private int IndicatorPos;
 
     public void EnterDigit(int digit)
     {
@@ -90,12 +88,12 @@ public class MicroscopeNumPad : MonoBehaviour
 
     private void StopIndicatorCycle()
     {
-        if (IsInvoking("IndicateCurrentInputField"))
-            CancelInvoke("IndicateCurrentInputField");
+        if (IsInvoking(nameof(IndicateCurrentInputField)))
+            CancelInvoke(nameof(IndicateCurrentInputField));
     }
 
     private void StartIndicatorCycle()
     {
-        InvokeRepeating("IndicateCurrentInputField", 0, 0.5f);
+        InvokeRepeating(nameof(IndicateCurrentInputField), 0, 0.5f);
     }
 }

--- a/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/MicroscopeOverlayTrigger.cs
+++ b/Assets/Laboratory/Components/BeaconApp Microscope/Scripts/MicroscopeOverlayTrigger.cs
@@ -17,6 +17,7 @@ public class MicroscopeOverlayTrigger : MonoBehaviour
         MicroscopeOverlay = GetComponentInChildren<MicroscopeScreenSpaceOverlay>();
         VignetteVolume = transform.Find("Vignette").GetComponent<PostProcessVolume>();
         DarkenVolume = transform.Find("Darken").GetComponent<PostProcessVolume>();
+        MicroscopeOverlay.DisableOverlay();
     }
 
     private void OnTriggerEnter(Collider other)

--- a/Assets/Laboratory/Prefabs/Microscope/MicroscopeComplete.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/MicroscopeComplete.prefab
@@ -3441,6 +3441,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   RevolvingNosePiece: {fileID: 3003226624814148780}
   direction: 0
+  m_OnMagnificationAdjusted:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &2891391447649695128
 GameObject:
   m_ObjectHideFlags: 0
@@ -6179,6 +6182,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   RevolvingNosePiece: {fileID: 3003226624814148780}
   direction: 1
+  m_OnMagnificationAdjusted:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &5965496784456730990
 GameObject:
   m_ObjectHideFlags: 0
@@ -9835,8 +9841,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.0002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
+        type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2730615
+      value: 0.0002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.0002
       objectReference: {fileID: 0}
     - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
@@ -9846,12 +9862,12 @@ PrefabInstance:
     - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.3243
+      value: 0.3304
       objectReference: {fileID: 0}
     - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.1838
+      value: -0.196
       objectReference: {fileID: 0}
     - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
@@ -9888,6 +9904,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5250468115519609669, guid: bb48f562c62ee2144b37cb7df8913621,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5250468115519609689, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
       propertyPath: m_Name
@@ -9896,17 +9917,7 @@ PrefabInstance:
     - target: {fileID: 5250468115661501753, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1492.47
-      objectReference: {fileID: 0}
-    - target: {fileID: 5250468115661501753, guid: bb48f562c62ee2144b37cb7df8913621,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 904
-      objectReference: {fileID: 0}
-    - target: {fileID: 5250468115661501753, guid: bb48f562c62ee2144b37cb7df8913621,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0.018001556
+      value: 1835
       objectReference: {fileID: 0}
     - target: {fileID: 5350608294451445278, guid: bb48f562c62ee2144b37cb7df8913621,
         type: 3}

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Chaetoceros Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Chaetoceros Diatom.prefab
@@ -2131,7 +2131,7 @@ GameObject:
   - component: {fileID: 7905402903220464904}
   - component: {fileID: 6869009899032690608}
   - component: {fileID: 4766849412727535980}
-  - component: {fileID: 7032106452670666132}
+  - component: {fileID: 6396129704841629450}
   m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
@@ -2182,7 +2182,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.8113208, g: 0.8113208, b: 0.8113208, a: 0.7176471}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2215,9 +2215,9 @@ MonoBehaviour:
   closedScale: 1.6
   openScale: 3.42
   startState: 0
-  hideWhenClosed: 0
+  closeAutomaticallyAfterSeconds: 10
   canvasToHideWhenClosed: {fileID: 0}
---- !u!114 &7032106452670666132
+--- !u!114 &6396129704841629450
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2226,26 +2226,53 @@ MonoBehaviour:
   m_GameObject: {fileID: 7774752137779317354}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 4766849412727535980}
-          m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
-          m_MethodName: ToggleOnOff
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 1
-          m_CallState: 2
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5105628090847162998}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4766849412727535980}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8169863602198394440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Chaetoceros Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Chaetoceros Diatom.prefab
@@ -807,6 +807,7 @@ GameObject:
   - component: {fileID: 220666886201546328}
   - component: {fileID: 596840352028947875}
   - component: {fileID: 1551526459665899665}
+  - component: {fileID: 3156449840971666525}
   m_Layer: 9
   m_Name: Chaetoceros Diatom
   m_TagString: Untagged
@@ -946,6 +947,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &3156449840971666525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807661012287408205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ExcludeObjects:
+  - {fileID: 7674940087569880141}
 --- !u!1 &3260145859081886444
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/PlanktonNotepad.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/PlanktonNotepad.prefab
@@ -685,6 +685,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3703879375833869294, guid: 3104c3e419e12de47bf89343580f372b,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4105132116659445627, guid: 3104c3e419e12de47bf89343580f372b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -859,6 +864,285 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2593754961303900974 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1640946880698381328, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3201980004995235823 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1825287995994282193, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3684283208478807338 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 439727778258104852, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1215720273669532051
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3684283208478807338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4355118876715270781}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7607014462783514039}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &7607014462783514039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3684283208478807338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca9ae3819a1a8a9448a43631f6c7b866, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  closedPosition: {x: -0.03, y: -0.004, z: 0}
+  openPosition: {x: 0, y: 0, z: 0}
+  closedScale: 1
+  openScale: 2
+  startState: 0
+  closeAutomaticallyAfterSeconds: 10
+  canvasToHideWhenClosed: {fileID: 0}
+--- !u!114 &4355118876715270781 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 669756032722183491, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5522643370705185229 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8763812433982557939, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3030105825315432545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5522643370705185229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2593754961303900974}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7837928480269805128}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &7837928480269805128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5522643370705185229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca9ae3819a1a8a9448a43631f6c7b866, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  closedPosition: {x: -0.03, y: -0.004, z: 0}
+  openPosition: {x: 0, y: 0, z: 0}
+  closedScale: 1
+  openScale: 2
+  startState: 0
+  closeAutomaticallyAfterSeconds: 10
+  canvasToHideWhenClosed: {fileID: 0}
+--- !u!1 &6199958258416032058 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7147673530006633988, guid: 3104c3e419e12de47bf89343580f372b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3835675018669516606}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3509878679275430238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6199958258416032058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3201980004995235823}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7095102162374547045}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &7095102162374547045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6199958258416032058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca9ae3819a1a8a9448a43631f6c7b866, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  closedPosition: {x: -0.03, y: -0.004, z: 0}
+  openPosition: {x: 0, y: 0, z: 0}
+  closedScale: 1
+  openScale: 2
+  startState: 0
+  closeAutomaticallyAfterSeconds: 10
+  canvasToHideWhenClosed: {fileID: 0}
 --- !u!1001 &6514338905546097570
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/PlanktonNotepadCanvas.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/PlanktonNotepadCanvas.prefab
@@ -32,7 +32,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4688211727252090166}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -287,12 +287,12 @@ RectTransform:
   m_Children:
   - {fileID: 5486411336616016219}
   m_Father: {fileID: 4105132116659445627}
-  m_RootOrder: 0
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 0.0305, y: -0.0025}
-  m_SizeDelta: {x: 0.04, y: 0.04}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.03, y: -0.004}
+  m_SizeDelta: {x: 0.039999995, y: 0.04}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &551139084122319457
 CanvasRenderer:
@@ -430,7 +430,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 4688211727252090166}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1264,7 +1264,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1562330118898485105}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1419,7 +1419,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1562330118898485105}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1740,7 +1740,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4688211727252090166}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -2334,7 +2334,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4105132116659445627}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -2508,11 +2508,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6651164097943374356}
   - {fileID: 1618108461211133112}
   - {fileID: 2904746525106526213}
   - {fileID: 229500682469463078}
   - {fileID: 3119138657292189558}
+  - {fileID: 6651164097943374356}
   m_Father: {fileID: 2916174214345488069}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2589,11 +2589,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1523116140341713027}
   - {fileID: 999884400710340562}
   - {fileID: 8323026132026607277}
   - {fileID: 5754139856482635718}
   - {fileID: 6207569171577543937}
+  - {fileID: 1523116140341713027}
   m_Father: {fileID: 2916174214345488069}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2860,7 +2860,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1562330118898485105}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -3037,12 +3037,12 @@ RectTransform:
   m_Children:
   - {fileID: 8762554506530795302}
   m_Father: {fileID: 4688211727252090166}
-  m_RootOrder: 0
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 0.0305, y: -0.0025}
-  m_SizeDelta: {x: 0.04, y: 0.04}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.03, y: -0.004}
+  m_SizeDelta: {x: 0.039999995, y: 0.04}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8736704236980511435
 CanvasRenderer:
@@ -3130,7 +3130,7 @@ RectTransform:
   m_Children:
   - {fileID: 5788744467907379718}
   m_Father: {fileID: 1562330118898485105}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3328,6 +3328,7 @@ GameObject:
   - component: {fileID: 8707993219749085003}
   - component: {fileID: 132789085635099875}
   - component: {fileID: 8624517711711372720}
+  - component: {fileID: 199546042820676987}
   m_Layer: 5
   m_Name: PlanktonNotepadCanvas
   m_TagString: Untagged
@@ -3400,7 +3401,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &8707993219749085003
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3443,6 +3444,60 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Slide: {fileID: 0}
+--- !u!114 &199546042820676987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7219361039529606747}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ced152fad2fb9a24893900939325d5ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LargerTextComponentSettings: []
+  LargerUnityUIObjectsSettings:
+  - Object: {fileID: 1619907248097117373}
+    Scale: 1.1
+    Width: 0
+    Height: 0
+    Position: {x: 0, y: 0, z: 0}
+    OldFontSize: 0
+    OldWidth: 0
+    OldHeight: 0
+    OldScale: {x: 0, y: 0, z: 0}
+    OldPosition: {x: 0, y: 0, z: 0}
+  - Object: {fileID: 7427240962453144326}
+    Scale: 1.1
+    Width: 0
+    Height: 0
+    Position: {x: 0, y: 0, z: 0}
+    OldFontSize: 0
+    OldWidth: 0
+    OldHeight: 0
+    OldScale: {x: 0, y: 0, z: 0}
+    OldPosition: {x: 0, y: 0, z: 0}
+  - Object: {fileID: 6689713492501282147}
+    Scale: 1.1
+    Width: 0
+    Height: 0
+    Position: {x: 0, y: 0, z: 0}
+    OldFontSize: 0
+    OldWidth: 0
+    OldHeight: 0
+    OldScale: {x: 0, y: 0, z: 0}
+    OldPosition: {x: 0, y: 0, z: 0}
+  - Object: {fileID: 5661856760243208067}
+    Scale: 1.1
+    Width: 0
+    Height: 0
+    Position: {x: 0, y: 0, z: 0}
+    OldFontSize: 0
+    OldWidth: 0
+    OldHeight: 0
+    OldScale: {x: 0, y: 0, z: 0}
+    OldPosition: {x: 0, y: 0, z: 0}
 --- !u!1 &7281889780268606410
 GameObject:
   m_ObjectHideFlags: 0
@@ -3477,7 +3532,7 @@ RectTransform:
   m_Children:
   - {fileID: 3510881804656208736}
   m_Father: {fileID: 4688211727252090166}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3693,7 +3748,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4105132116659445627}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -3865,13 +3920,13 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 3703879375833869294}
   - {fileID: 4521665058560178672}
   - {fileID: 7231510726697694822}
   - {fileID: 5820274131331295768}
   - {fileID: 5422239877887558157}
+  - {fileID: 3703879375833869294}
   m_Father: {fileID: 2916174214345488069}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4473,12 +4528,12 @@ RectTransform:
   m_Children:
   - {fileID: 1335927192581627379}
   m_Father: {fileID: 1562330118898485105}
-  m_RootOrder: 0
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 0.0305, y: -0.0025}
-  m_SizeDelta: {x: 0.04, y: 0.04}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.03, y: -0.004}
+  m_SizeDelta: {x: 0.039999995, y: 0.04}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8909410212374660595
 CanvasRenderer:
@@ -4563,7 +4618,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 4105132116659445627}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4642,7 +4697,7 @@ RectTransform:
   m_Children:
   - {fileID: 5164183059665031523}
   m_Father: {fileID: 4105132116659445627}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Pseudo-nitzschia Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Pseudo-nitzschia Diatom.prefab
@@ -751,6 +751,7 @@ GameObject:
   - component: {fileID: 220666886201546328}
   - component: {fileID: 596840352028947875}
   - component: {fileID: 4569753781421180639}
+  - component: {fileID: 8192542681241583672}
   m_Layer: 9
   m_Name: Pseudo-nitzschia Diatom
   m_TagString: Untagged
@@ -890,6 +891,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &8192542681241583672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807661012287408205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ExcludeObjects:
+  - {fileID: 7674940087569880141}
 --- !u!1 &3641842458971653017
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Pseudo-nitzschia Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Pseudo-nitzschia Diatom.prefab
@@ -2071,7 +2071,7 @@ GameObject:
   - component: {fileID: 7905402903220464904}
   - component: {fileID: 6869009899032690608}
   - component: {fileID: 4766849412727535980}
-  - component: {fileID: 7032106452670666132}
+  - component: {fileID: 6459591974780173132}
   m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
@@ -2122,7 +2122,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.8113208, g: 0.8113208, b: 0.8113208, a: 0.7176471}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2155,9 +2155,9 @@ MonoBehaviour:
   closedScale: 1.6
   openScale: 3.42
   startState: 0
-  hideWhenClosed: 0
+  closeAutomaticallyAfterSeconds: 10
   canvasToHideWhenClosed: {fileID: 0}
---- !u!114 &7032106452670666132
+--- !u!114 &6459591974780173132
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2166,26 +2166,53 @@ MonoBehaviour:
   m_GameObject: {fileID: 7774752137779317354}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 4766849412727535980}
-          m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
-          m_MethodName: ToggleOnOff
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 1
-          m_CallState: 2
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5105628090847162998}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4766849412727535980}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8169863602198394440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Skeletonema Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Skeletonema Diatom.prefab
@@ -863,6 +863,7 @@ GameObject:
   - component: {fileID: 220666886201546328}
   - component: {fileID: 596840352028947875}
   - component: {fileID: 1470845409779658485}
+  - component: {fileID: 5018678874888266744}
   m_Layer: 9
   m_Name: Skeletonema Diatom
   m_TagString: Untagged
@@ -1002,6 +1003,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5018678874888266744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807661012287408205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ExcludeObjects:
+  - {fileID: 7674940087569880141}
 --- !u!1 &3641842458971653017
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/A4/Skeletonema Diatom.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/A4/Skeletonema Diatom.prefab
@@ -2130,7 +2130,7 @@ GameObject:
   - component: {fileID: 7905402903220464904}
   - component: {fileID: 6869009899032690608}
   - component: {fileID: 4766849412727535980}
-  - component: {fileID: 7032106452670666132}
+  - component: {fileID: 1854827782718852830}
   m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
@@ -2181,7 +2181,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.8113208, g: 0.8113208, b: 0.8113208, a: 0.7176471}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2214,9 +2214,9 @@ MonoBehaviour:
   closedScale: 1.6
   openScale: 3.42
   startState: 0
-  hideWhenClosed: 0
+  closeAutomaticallyAfterSeconds: 10
   canvasToHideWhenClosed: {fileID: 0}
---- !u!114 &7032106452670666132
+--- !u!114 &1854827782718852830
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2225,26 +2225,53 @@ MonoBehaviour:
   m_GameObject: {fileID: 7774752137779317354}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 4766849412727535980}
-          m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
-          m_MethodName: ToggleOnOff
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 1
-          m_CallState: 2
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5105628090847162998}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4766849412727535980}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
+        m_MethodName: ToggleOnOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8169863602198394440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Laboratory/Prefabs/Microscope/UI/MicroscopeMonitor.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/MicroscopeMonitor.prefab
@@ -221,8 +221,6 @@ GameObject:
   m_Component:
   - component: {fileID: 9044643483520620177}
   - component: {fileID: 6205695205700548388}
-  - component: {fileID: 4992827241394285322}
-  - component: {fileID: 7671051986350739038}
   - component: {fileID: 7966042798719441944}
   - component: {fileID: 8333569568921211700}
   - component: {fileID: 6293989498109951957}
@@ -240,19 +238,21 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 628175404421577428}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0002656749}
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6952187708807264808}
+  - {fileID: 2295734275053653563}
+  - {fileID: 439475219088970990}
+  - {fileID: 5222488274202727662}
   m_Father: {fileID: 7499267524034651033}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -82.5, y: 0}
-  m_SizeDelta: {x: 115, y: 240}
+  m_AnchoredPosition: {x: -110, y: 0}
+  m_SizeDelta: {x: 260, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6205695205700548388
 CanvasRenderer:
@@ -262,49 +262,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 628175404421577428}
   m_CullTransparentMesh: 1
---- !u!114 &4992827241394285322
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 628175404421577428}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.7783019, g: 0.89339906, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.3
---- !u!65 &7671051986350739038
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 628175404421577428}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 110, y: 228.7, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
 --- !u!114 &7966042798719441944
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -358,7 +315,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 4992827241394285322}
+  m_TargetGraphic: {fileID: 6930004924422793771}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -419,6 +376,82 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!1 &840095927957119419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8858037270261549180}
+  - component: {fileID: 7678026939723341569}
+  - component: {fileID: 6124082529254633942}
+  m_Layer: 2
+  m_Name: ArrowImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8858037270261549180
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840095927957119419}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3843831014175109713}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -190, y: -12.000004}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7678026939723341569
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840095927957119419}
+  m_CullTransparentMesh: 1
+--- !u!114 &6124082529254633942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840095927957119419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1029021938151320802
 GameObject:
   m_ObjectHideFlags: 0
@@ -862,10 +895,60 @@ MonoBehaviour:
         m_VariantData:
         - localeIdentifier:
             m_Code: en
-          value: 320.6
+          value: 293.2
         - localeIdentifier:
             m_Code: no
-          value: 320
+          value: 277.3
+--- !u!1 &1714354323104511747
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4893536562098141049}
+  - component: {fileID: 4383743302142845816}
+  m_Layer: 2
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4893536562098141049
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714354323104511747}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3843831014175109713}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!65 &4383743302142845816
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714354323104511747}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 270, y: 170, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!1 &2045410420818508459
 GameObject:
   m_ObjectHideFlags: 0
@@ -939,94 +1022,6 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
---- !u!1 &2638746186709347169
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4854313701613790494}
-  - component: {fileID: 8422469963239248656}
-  - component: {fileID: 2184307992027891402}
-  - component: {fileID: 6386776005652248487}
-  m_Layer: 2
-  m_Name: RawImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4854313701613790494
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2638746186709347169}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 568274869504471000}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 69.1, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8422469963239248656
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2638746186709347169}
-  m_CullTransparentMesh: 1
---- !u!114 &2184307992027891402
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2638746186709347169}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Texture: {fileID: 2800000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0.01
-    y: 0
-    width: 1
-    height: 1
---- !u!114 &6386776005652248487
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2638746186709347169}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 1
-  m_AspectRatio: 0.5
 --- !u!1 &2747507711972517579
 GameObject:
   m_ObjectHideFlags: 0
@@ -1235,6 +1230,148 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   input: 5
+--- !u!1 &3048150032379014424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2796264151704544418}
+  - component: {fileID: 553554777530483171}
+  m_Layer: 2
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2796264151704544418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3048150032379014424}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 568274869504471000}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!65 &553554777530483171
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3048150032379014424}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 270, y: 170, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
+--- !u!1 &3132986385437601901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2295734275053653563}
+  - component: {fileID: 1446226597743852122}
+  - component: {fileID: 6930004924422793771}
+  - component: {fileID: 1185424270491586923}
+  m_Layer: 2
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2295734275053653563
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3132986385437601901}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9044643483520620177}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1446226597743852122
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3132986385437601901}
+  m_CullTransparentMesh: 1
+--- !u!114 &6930004924422793771
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3132986385437601901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 214273148a9367f498d4b7d770ebf965, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
+--- !u!114 &1185424270491586923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3132986385437601901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &3793497115136203136
 GameObject:
   m_ObjectHideFlags: 0
@@ -1250,6 +1387,7 @@ GameObject:
   - component: {fileID: 8254721754813198404}
   - component: {fileID: 5834444375544603148}
   - component: {fileID: 1747908501443955783}
+  - component: {fileID: 8024830041219228998}
   m_Layer: 2
   m_Name: ButtonFaster
   m_TagString: Untagged
@@ -1276,7 +1414,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -100, y: 100}
-  m_SizeDelta: {x: 150, y: 150}
+  m_SizeDelta: {x: 140, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1013425484177671360
 CanvasRenderer:
@@ -1299,15 +1437,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7783019, g: 0.89339906, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 0a477ee27784b97409a32d4284fdce4d, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1327,8 +1465,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 140, y: 140, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
+  m_Size: {x: 160, y: 160, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!114 &8254721754813198404
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1439,6 +1577,21 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!114 &8024830041219228998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3793497115136203136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &3961294356067273963
 GameObject:
   m_ObjectHideFlags: 0
@@ -1449,8 +1602,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2477739866976943502}
   - component: {fileID: 8376497546866722651}
-  - component: {fileID: 5846517005513101338}
-  - component: {fileID: 5763895113256000462}
   - component: {fileID: 8374482413022549792}
   - component: {fileID: 1797386476481586719}
   - component: {fileID: 5788592801619546105}
@@ -1468,19 +1619,21 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3961294356067273963}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0002656749}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 386980118666900531}
   - {fileID: 5350608294451445278}
+  - {fileID: 7920775325976923546}
   m_Father: {fileID: 7499267524034651033}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 82.5, y: 0}
-  m_SizeDelta: {x: 115, y: 240}
+  m_AnchoredPosition: {x: 110, y: 0}
+  m_SizeDelta: {x: 260, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8376497546866722651
 CanvasRenderer:
@@ -1490,49 +1643,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3961294356067273963}
   m_CullTransparentMesh: 1
---- !u!114 &5846517005513101338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3961294356067273963}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.3
---- !u!65 &5763895113256000462
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3961294356067273963}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 110, y: 228.7, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
 --- !u!114 &8374482413022549792
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1586,7 +1696,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 5846517005513101338}
+  m_TargetGraphic: {fileID: 6063072318570454141}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -1647,6 +1757,174 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!1 &4379554895699809871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6263731374639880645}
+  - component: {fileID: 2832518450455505613}
+  - component: {fileID: 4900528893112626020}
+  m_Layer: 2
+  m_Name: ArrowImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6263731374639880645
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379554895699809871}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 568274869504471000}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -190, y: -12.000004}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2832518450455505613
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379554895699809871}
+  m_CullTransparentMesh: 1
+--- !u!114 &4900528893112626020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379554895699809871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4900272178261768687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 386980118666900531}
+  - component: {fileID: 5914494894418395305}
+  - component: {fileID: 6063072318570454141}
+  - component: {fileID: 2889135163234195698}
+  m_Layer: 2
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &386980118666900531
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4900272178261768687}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2477739866976943502}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5914494894418395305
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4900272178261768687}
+  m_CullTransparentMesh: 1
+--- !u!114 &6063072318570454141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4900272178261768687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 214273148a9367f498d4b7d770ebf965, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
+--- !u!114 &2889135163234195698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4900272178261768687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &5250468115519609689
 GameObject:
   m_ObjectHideFlags: 0
@@ -1673,8 +1951,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5250468115519609689}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.5583, z: 0.17904}
-  m_LocalScale: {x: 0.48760998, y: 0.27306157, z: 0.024780156}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5250468115661501753}
@@ -1710,8 +1988,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  graphicRaycasters:
-  - {fileID: 5250468115661501752}
 --- !u!1 &5250468115661501758
 GameObject:
   m_ObjectHideFlags: 0
@@ -1724,6 +2000,7 @@ GameObject:
   - component: {fileID: 5250468115661501754}
   - component: {fileID: 5250468115661501755}
   - component: {fileID: 5250468115661501752}
+  - component: {fileID: 7941047701133177506}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1740,7 +2017,7 @@ RectTransform:
   m_GameObject: {fileID: 5250468115661501758}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -0.52}
-  m_LocalScale: {x: 0.00050158787, y: 0.0008597162, z: 0.0008974073}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7499267524034651033}
@@ -1813,6 +2090,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &7941047701133177506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5250468115661501758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ExcludeObjects:
+  - {fileID: 543604675428751982}
 --- !u!1 &5264278439461315167
 GameObject:
   m_ObjectHideFlags: 0
@@ -1969,8 +2260,6 @@ GameObject:
   m_Component:
   - component: {fileID: 3843831014175109713}
   - component: {fileID: 8753895122669851508}
-  - component: {fileID: 1607828439650321427}
-  - component: {fileID: 7236390977701733835}
   - component: {fileID: 449299170193799102}
   - component: {fileID: 1495768211811350294}
   - component: {fileID: 7983429738674078505}
@@ -1988,19 +2277,21 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5967673803852514701}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0002656749}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1029488786447599208}
+  - {fileID: 7046223907898406609}
+  - {fileID: 8858037270261549180}
+  - {fileID: 4893536562098141049}
   m_Father: {fileID: 7499267524034651033}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 90.5}
-  m_SizeDelta: {x: 260, y: 131}
+  m_AnchoredPosition: {x: 0, y: 110}
+  m_SizeDelta: {x: 260, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8753895122669851508
 CanvasRenderer:
@@ -2010,49 +2301,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5967673803852514701}
   m_CullTransparentMesh: 1
---- !u!114 &1607828439650321427
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5967673803852514701}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.7783019, g: 0.89339906, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.3
---- !u!65 &7236390977701733835
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5967673803852514701}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 256, y: 120, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
 --- !u!114 &449299170193799102
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2106,7 +2354,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1607828439650321427}
+  m_TargetGraphic: {fileID: 2621017301586052029}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -2167,6 +2415,132 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!1 &6069267347904796895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 439475219088970990}
+  - component: {fileID: 2823193034097390529}
+  - component: {fileID: 382107573102159219}
+  m_Layer: 2
+  m_Name: ArrowImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &439475219088970990
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6069267347904796895}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9044643483520620177}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -190, y: -12.000004}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2823193034097390529
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6069267347904796895}
+  m_CullTransparentMesh: 1
+--- !u!114 &382107573102159219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6069267347904796895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6299549538978543347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5222488274202727662}
+  - component: {fileID: 8057100789691960413}
+  m_Layer: 2
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5222488274202727662
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299549538978543347}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9044643483520620177}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!65 &8057100789691960413
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299549538978543347}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 270, y: 170, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!1 &6677096793446403123
 GameObject:
   m_ObjectHideFlags: 0
@@ -2272,6 +2646,98 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   input: 4
+--- !u!1 &6811041418598880256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2315627482513336307}
+  - component: {fileID: 4922454230347133332}
+  - component: {fileID: 8716214659811589791}
+  - component: {fileID: 909023512248218872}
+  m_Layer: 2
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2315627482513336307
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6811041418598880256}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 568274869504471000}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4922454230347133332
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6811041418598880256}
+  m_CullTransparentMesh: 1
+--- !u!114 &8716214659811589791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6811041418598880256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 214273148a9367f498d4b7d770ebf965, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
+--- !u!114 &909023512248218872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6811041418598880256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &6862776259392190789
 GameObject:
   m_ObjectHideFlags: 0
@@ -2636,6 +3102,7 @@ GameObject:
   - component: {fileID: 6979032411999679282}
   - component: {fileID: 6917801387876090187}
   - component: {fileID: 4292498039823071207}
+  - component: {fileID: 8449270645762059232}
   m_Layer: 2
   m_Name: ButtonSlower
   m_TagString: Untagged
@@ -2662,7 +3129,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -272, y: 100}
-  m_SizeDelta: {x: 150, y: 150}
+  m_SizeDelta: {x: 140, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2054841029064291583
 CanvasRenderer:
@@ -2685,15 +3152,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7783019, g: 0.89339906, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 0a477ee27784b97409a32d4284fdce4d, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -2713,8 +3180,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 140, y: 140, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
+  m_Size: {x: 160, y: 160, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!114 &6979032411999679282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2825,6 +3292,21 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!114 &8449270645762059232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7358639943370061173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &7461936838942959191
 GameObject:
   m_ObjectHideFlags: 0
@@ -3131,8 +3613,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 256, y: 120, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
+  m_Size: {x: 412, y: 170, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!114 &6263152255036207280
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3330,10 +3812,9 @@ GameObject:
   m_Component:
   - component: {fileID: 5350608294451445278}
   - component: {fileID: 4132590072569024171}
-  - component: {fileID: 5631035492476914342}
-  - component: {fileID: 3546975048350496500}
+  - component: {fileID: 5340295844151090231}
   m_Layer: 2
-  m_Name: RawImage
+  m_Name: ArrowImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3346,18 +3827,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8092213032895611986}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2477739866976943502}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 69.1, y: 0}
+  m_SizeDelta: {x: -190, y: -12.000004}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4132590072569024171
 CanvasRenderer:
@@ -3367,7 +3848,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8092213032895611986}
   m_CullTransparentMesh: 1
---- !u!114 &5631035492476914342
+--- !u!114 &5340295844151090231
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3376,39 +3857,28 @@ MonoBehaviour:
   m_GameObject: {fileID: 8092213032895611986}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 2800000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0.01
-    y: 0
-    width: 1
-    height: 1
---- !u!114 &3546975048350496500
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8092213032895611986}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 1
-  m_AspectRatio: 0.5
---- !u!1 &8206987101934058581
+  m_Sprite: {fileID: 21300000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8288763556615082425
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3416,174 +3886,140 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6952187708807264808}
-  - component: {fileID: 5975466723468070415}
-  - component: {fileID: 7076853460238263470}
-  - component: {fileID: 744064141762321942}
+  - component: {fileID: 7046223907898406609}
+  - component: {fileID: 88434055439484105}
+  - component: {fileID: 2621017301586052029}
+  - component: {fileID: 2500773539046380805}
   m_Layer: 2
-  m_Name: RawImage
+  m_Name: Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &6952187708807264808
+--- !u!224 &7046223907898406609
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8206987101934058581}
+  m_GameObject: {fileID: 8288763556615082425}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9044643483520620177}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 69.1, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5975466723468070415
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8206987101934058581}
-  m_CullTransparentMesh: 1
---- !u!114 &7076853460238263470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8206987101934058581}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Texture: {fileID: 2800000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0.01
-    y: 0
-    width: 1
-    height: 1
---- !u!114 &744064141762321942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8206987101934058581}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 1
-  m_AspectRatio: 0.5
---- !u!1 &9165746136001747228
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1029488786447599208}
-  - component: {fileID: 3282884224847043227}
-  - component: {fileID: 6441834316506068268}
-  - component: {fileID: 7905522235973920953}
-  m_Layer: 2
-  m_Name: RawImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1029488786447599208
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9165746136001747228}
-  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3843831014175109713}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 69.1, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3282884224847043227
+--- !u!222 &88434055439484105
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9165746136001747228}
+  m_GameObject: {fileID: 8288763556615082425}
   m_CullTransparentMesh: 1
---- !u!114 &6441834316506068268
+--- !u!114 &2621017301586052029
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9165746136001747228}
+  m_GameObject: {fileID: 8288763556615082425}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 2800000, guid: da07fcfe547d0984c87a8fcbf8b4e2a6, type: 3}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0.01
-    y: 0
-    width: 1
-    height: 1
---- !u!114 &7905522235973920953
+  m_Sprite: {fileID: 21300000, guid: 214273148a9367f498d4b7d770ebf965, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
+--- !u!114 &2500773539046380805
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9165746136001747228}
+  m_GameObject: {fileID: 8288763556615082425}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AspectMode: 1
-  m_AspectRatio: 0.5
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 3, y: 3}
+  m_UseGraphicAlpha: 1
+--- !u!1 &8895563900212305116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7920775325976923546}
+  - component: {fileID: 6864114142767605489}
+  m_Layer: 2
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7920775325976923546
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8895563900212305116}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2477739866976943502}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!65 &6864114142767605489
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8895563900212305116}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 270, y: 170, z: 74}
+  m_Center: {x: 0, y: 0, z: 19.2}
 --- !u!1 &9192576430777306353
 GameObject:
   m_ObjectHideFlags: 0
@@ -3594,8 +4030,6 @@ GameObject:
   m_Component:
   - component: {fileID: 568274869504471000}
   - component: {fileID: 5250558122152516773}
-  - component: {fileID: 1140774660356608015}
-  - component: {fileID: 5367293279190490450}
   - component: {fileID: 8558069609241864904}
   - component: {fileID: 7213101763406473434}
   - component: {fileID: 1018310842993308475}
@@ -3613,19 +4047,21 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9192576430777306353}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0002656749}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4854313701613790494}
+  - {fileID: 2315627482513336307}
+  - {fileID: 6263731374639880645}
+  - {fileID: 2796264151704544418}
   m_Father: {fileID: 7499267524034651033}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -90.70001}
-  m_SizeDelta: {x: 260, y: 131.40002}
+  m_AnchoredPosition: {x: 0, y: -110}
+  m_SizeDelta: {x: 260, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5250558122152516773
 CanvasRenderer:
@@ -3635,49 +4071,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9192576430777306353}
   m_CullTransparentMesh: 1
---- !u!114 &1140774660356608015
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9192576430777306353}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.7783019, g: 0.89339906, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.3
---- !u!65 &5367293279190490450
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9192576430777306353}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 256, y: 120, z: 1322}
-  m_Center: {x: 0, y: 0, z: 543}
 --- !u!114 &8558069609241864904
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3731,7 +4124,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1140774660356608015}
+  m_TargetGraphic: {fileID: 8716214659811589791}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Laboratory/Prefabs/Microscope/UI/MicroscopeMonitor.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/MicroscopeMonitor.prefab
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1502,7 +1502,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1678,7 +1678,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -2336,7 +2336,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -3217,7 +3217,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -4106,7 +4106,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}

--- a/Assets/Laboratory/Prefabs/Microscope/UI/Numpad.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/Numpad.prefab
@@ -371,7 +371,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -709,7 +709,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &4618636318969918378
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -859,7 +859,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1035,7 +1035,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1346,7 +1346,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1522,7 +1522,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -1833,7 +1833,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -2279,7 +2279,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -2455,7 +2455,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -2845,7 +2845,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -2931,9 +2931,8 @@ GameObject:
   - component: {fileID: 2564516291890535997}
   - component: {fileID: 4423081630484671500}
   - component: {fileID: 7058660590881270749}
-  - component: {fileID: 531310006106272521}
   m_Layer: 5
-  m_Name: ButtonClose
+  m_Name: Cross
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2981,7 +2980,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.16078432, g: 0.16078432, b: 0.16078432, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2997,74 +2996,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 3215
---- !u!114 &531310006106272521
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6924125506953134853}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 7058660590881270749}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: FloatingNumPad, Assembly-CSharp
-        m_MethodName: DisableAndScaleDown
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 4016438882112504476}
-        m_TargetAssemblyTypeName: MicroscopeNumPad, Assembly-CSharp
-        m_MethodName: RemoveCurrentInputField
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!1 &7103894347073174711
 GameObject:
   m_ObjectHideFlags: 0
@@ -3166,7 +3097,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -3588,7 +3519,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -3898,7 +3829,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -3920,8 +3851,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: FloatingNumPad, Assembly-CSharp
+      - m_Target: {fileID: 8622857125286269632}
+        m_TargetAssemblyTypeName: FloatingUIElement, Assembly-CSharp
         m_MethodName: DisableAndScaleDown
         m_Mode: 1
         m_Arguments:

--- a/Assets/Laboratory/Prefabs/Microscope/UI/Numpad.prefab
+++ b/Assets/Laboratory/Prefabs/Microscope/UI/Numpad.prefab
@@ -75,8 +75,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -210,8 +210,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -332,7 +332,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.4481132, b: 0.45232612, a: 1}
+  m_Color: {r: 0.8980392, g: 0.078431375, b: 0.27058825, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -524,8 +524,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -820,7 +820,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -996,7 +996,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1185,8 +1185,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -1307,7 +1307,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1483,7 +1483,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1672,8 +1672,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -1794,7 +1794,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1983,8 +1983,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2118,8 +2118,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2240,7 +2240,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2416,7 +2416,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2684,8 +2684,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2806,7 +2806,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2920,6 +2920,151 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 1
           m_CallState: 2
+--- !u!1 &6924125506953134853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2564516291890535997}
+  - component: {fileID: 4423081630484671500}
+  - component: {fileID: 7058660590881270749}
+  - component: {fileID: 531310006106272521}
+  m_Layer: 5
+  m_Name: ButtonClose
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2564516291890535997
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6924125506953134853}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 5552688389298721033}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.015, y: 0.015}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4423081630484671500
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6924125506953134853}
+  m_CullTransparentMesh: 1
+--- !u!114 &7058660590881270749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6924125506953134853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.16078432, g: 0.16078432, b: 0.16078432, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1ba384014967d2540a23a21ca126dc57, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3215
+--- !u!114 &531310006106272521
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6924125506953134853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7058660590881270749}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: FloatingNumPad, Assembly-CSharp
+        m_MethodName: DisableAndScaleDown
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 4016438882112504476}
+        m_TargetAssemblyTypeName: MicroscopeNumPad, Assembly-CSharp
+        m_MethodName: RemoveCurrentInputField
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &7103894347073174711
 GameObject:
   m_ObjectHideFlags: 0
@@ -2982,7 +3127,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -3171,8 +3316,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -3404,7 +3549,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.7764706, g: 0.89411765, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -3593,8 +3738,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -3683,7 +3828,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.39999998, y: 0.39999998, z: 0.39999998}
   m_ConstrainProportionsScale: 1
-  m_Children: []
+  m_Children:
+  - {fileID: 2564516291890535997}
   m_Father: {fileID: 8797910025107472304}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3713,14 +3859,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.90588236, g: 0.90588236, b: 0.90588236, a: 1}
+  m_Color: {r: 0.8980392, g: 0.078431375, b: 0.27058825, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: c16164c3a5fdc0e45b333b8d1ae32ae7, type: 3}
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3729,7 +3875,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 3215
+  m_PixelsPerUnitMultiplier: 27.0791
 --- !u!114 &5526616387536250796
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3873,8 +4019,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 4280887593
+  m_fontColor: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Assets/VR4VET/Components/NPC/Prefabs/AnswerButton.prefab
+++ b/Assets/VR4VET/Components/NPC/Prefabs/AnswerButton.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.517, g: 0.57339996, b: 0.94, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -77,7 +77,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 2
 --- !u!114 &8793318279688643564
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -100,7 +100,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/VR4VET/Components/NPC/Prefabs/NPC.prefab
+++ b/Assets/VR4VET/Components/NPC/Prefabs/NPC.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: -13438200366404635}
   - component: {fileID: 4870013279876444523}
   - component: {fileID: 5635634451546480403}
+  - component: {fileID: 3550739920502420970}
   m_Layer: 0
   m_Name: NPC
   m_TagString: Untagged
@@ -152,7 +153,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5382d013af63bd847a2692c71533629e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _parentInCanvas: {fileID: 2393529784512754671}
+  _answerButtonContainer: {fileID: 2393529784512754671}
+  _dialogueCanvas: {fileID: 2983172922030219317}
   _buttonPrefab: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
     type: 3}
 --- !u!114 &1615359058989093574
@@ -223,9 +225,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  graphicRaycasters:
-  - {fileID: 1190615708944818440}
-  - {fileID: 1996178629585652332}
+--- !u!114 &3550739920502420970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 142329030213301039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &389399547921113031
 GameObject:
   m_ObjectHideFlags: 0
@@ -315,17 +326,18 @@ RectTransform:
   m_GameObject: {fileID: 581411041544405079}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_LocalScale: {x: 1.2, y: 1.2, z: 1.2}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 4253522754679393812}
   m_Father: {fileID: 1541848699851475108}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 70, y: 40}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -2, y: -2}
   m_SizeDelta: {x: 15, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &1639337324360732203
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -347,14 +359,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.98039216, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 9e482da4f22318845b4dab6db4202f9b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 0a477ee27784b97409a32d4284fdce4d, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -386,7 +398,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -453,10 +465,10 @@ RectTransform:
   m_Father: {fileID: 1541848699851475108}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &850035737980274742
 CanvasRenderer:
@@ -479,14 +491,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.5660378, g: 0.5660378, b: 0.5660378, a: 0.078431375}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -495,7 +507,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 2.41
 --- !u!1 &715794130603018707
 GameObject:
   m_ObjectHideFlags: 0
@@ -524,17 +536,17 @@ RectTransform:
   m_GameObject: {fileID: 715794130603018707}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.2, y: 1.2, z: 1.2}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1541848699851475108}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -70, y: 40}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 2, y: -2}
   m_SizeDelta: {x: 15, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!222 &8436037145267135990
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -556,7 +568,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.5372549, g: 0.6039216, b: 0.9803922, a: 1}
+  m_Color: {r: 0.5411765, g: 0.6, b: 0.9803922, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -595,7 +607,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -799,10 +811,10 @@ RectTransform:
   m_Father: {fileID: 7862360960127886424}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2393529784512754671
 GameObject:
@@ -813,6 +825,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4496149770235420628}
+  - component: {fileID: 2685793406395992294}
   m_Layer: 0
   m_Name: AnswerButtonContainer
   m_TagString: Untagged
@@ -831,15 +844,47 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 765877447487343280}
+  - {fileID: 7430530388837708558}
+  - {fileID: 5592299482546064153}
+  - {fileID: 7907515691043001392}
+  - {fileID: 7519930910732343925}
+  - {fileID: 3574267922561020322}
+  - {fileID: 7584427286344966371}
+  - {fileID: 5829785099701392532}
   m_Father: {fileID: 7862360960127886424}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 2}
+  m_SizeDelta: {x: 155.2, y: 18.9}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &2685793406395992294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2393529784512754671}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 30, y: 20}
+  m_Spacing: {x: 3.24, y: 0}
+  m_Constraint: 2
+  m_ConstraintCount: 1
 --- !u!1 &2719027325604141251
 GameObject:
   m_ObjectHideFlags: 0
@@ -955,7 +1000,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 1}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 155.2, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &7453494520029333589
 Canvas:
@@ -1192,8 +1237,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 2}
-  m_SizeDelta: {x: 150, y: 60}
+  m_AnchoredPosition: {x: 0, y: 0.5}
+  m_SizeDelta: {x: 135.3, y: 52}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5969025953116391288
 CanvasRenderer:
@@ -1292,3 +1337,1089 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8512330232846988332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4253522754679393812}
+  - component: {fileID: 4365159682022241008}
+  - component: {fileID: 7901942734797140162}
+  m_Layer: 0
+  m_Name: ArrowIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4253522754679393812
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512330232846988332}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8578978034099889949}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 7.5, y: 7.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4365159682022241008
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512330232846988332}
+  m_CullTransparentMesh: 1
+--- !u!114 &7901942734797140162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512330232846988332}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5b2af041ef5785f4f95c2930c2320ca7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &1530932538244764198
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &3574267922561020322 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1530932538244764198}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3315880565287119156
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &765877447487343280 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 3315880565287119156}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4880251287030108298
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &7430530388837708558 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4880251287030108298}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5267396361745741748
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &7907515691043001392 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 5267396361745741748}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5546332369072847345
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &7519930910732343925 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 5546332369072847345}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5613141943332045671
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &7584427286344966371 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 5613141943332045671}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7583912742558001309
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &5592299482546064153 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 7583912742558001309}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8377575038180210448
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4496149770235420628}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: AnswerButton (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!224 &5829785099701392532 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 8377575038180210448}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/VR4VET/Components/NPC/Prefabs/NPC.prefab
+++ b/Assets/VR4VET/Components/NPC/Prefabs/NPC.prefab
@@ -155,6 +155,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _answerButtonContainer: {fileID: 2393529784512754671}
   _dialogueCanvas: {fileID: 2983172922030219317}
+  _speakButton: {fileID: 2217410557348771034}
   _buttonPrefab: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
     type: 3}
 --- !u!114 &1615359058989093574
@@ -389,7 +390,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: -1
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -808,6 +809,7 @@ RectTransform:
   - {fileID: 8764369536982710703}
   - {fileID: 8578978034099889949}
   - {fileID: 7103094908301478801}
+  - {fileID: 6462197740936005407}
   m_Father: {fileID: 7862360960127886424}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -987,7 +989,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2983172922030219317}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0.55}
   m_LocalScale: {x: 0.008, y: 0.008, z: 0.008}
   m_ConstrainProportionsScale: 0
@@ -1299,7 +1301,7 @@ MonoBehaviour:
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 8
+  m_fontSizeMin: 7
   m_fontSizeMax: 18
   m_fontStyle: 0
   m_HorizontalAlignment: 2
@@ -1649,6 +1651,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089269959364180221, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
         type: 3}
@@ -2422,4 +2429,135 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
     type: 3}
   m_PrefabInstance: {fileID: 8377575038180210448}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9010286881860658331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1541848699851475108}
+    m_Modifications:
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeakButton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56a2b1470a515fa4a9969726ac78b7d1, type: 3}
+--- !u!1 &2217410557348771034 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7192014449640984641, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 9010286881860658331}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6462197740936005407 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2640427375123768196, guid: 56a2b1470a515fa4a9969726ac78b7d1,
+    type: 3}
+  m_PrefabInstance: {fileID: 9010286881860658331}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
@@ -1,22 +1,38 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
+using Unity.XR.CoreUtils;
 using UnityEngine;
+using UnityEngine.UI;
 using Button = UnityEngine.UI.Button;
 
 public class ButtonSpawner : MonoBehaviour
 {
-    [SerializeField] private GameObject _parentInCanvas;
+    [SerializeField] private GameObject _answerButtonContainer;
+    [SerializeField] private GameObject _dialogueCanvas;
+    private Rect _dialogueCanvasRect;
     [SerializeField] private GameObject _buttonPrefab;
     // max 4 buttons
     [HideInInspector] private GameObject[] _buttonsSpawned = new GameObject[4];
     [HideInInspector] private DialogueBoxController _dialogueBoxController;
     [HideInInspector] public static event Action<string> OnAnswer;
 
+    private List<GameObject> _answerButtons = new();
+
     void Start() {
         _dialogueBoxController = GetComponent<DialogueBoxController>();
         if (_dialogueBoxController == null ) {
             Debug.LogError("The NPC missing the DialogueBoxController script");
+        }
+        
+        _dialogueCanvasRect = _dialogueCanvas.GetComponent<RectTransform>().rect;
+
+
+        foreach (Button child in _answerButtonContainer.GetComponentsInChildren<Button>())
+        {
+            if (child != _answerButtonContainer.transform)
+                _answerButtons.Add(child.gameObject);
         }
     }
 
@@ -40,61 +56,26 @@ public class ButtonSpawner : MonoBehaviour
  
     // max 4 buttons
     void AddAnswerQuestionNumberListener() {
-        for (int i = 0; i < _buttonsSpawned.Count(); i++)
+        foreach (GameObject answerButton in _answerButtons)
         {
-            if(_buttonsSpawned[i] != null) {
-                switch (i)
-                {
-                    case 0:
-                        _buttonsSpawned[0].GetComponent<Button>().onClick.AddListener(() => {
-                            OnAnswer?.Invoke(_buttonsSpawned[0].GetComponentInChildren<TextMeshProUGUI>().text); 
-                            _dialogueBoxController.AnswerQuestion(0);
-                        });
-                        break;
-                    case 1:
-                        _buttonsSpawned[1].GetComponent<Button>().onClick.AddListener(() => { 
-                            OnAnswer?.Invoke(_buttonsSpawned[1].GetComponentInChildren<TextMeshProUGUI>().text); 
-                            _dialogueBoxController.AnswerQuestion(1);
-                        });
-                        break;
-                    case 2:
-                        _buttonsSpawned[2].GetComponent<Button>().onClick.AddListener(() => { 
-                            OnAnswer?.Invoke(_buttonsSpawned[2].GetComponentInChildren<TextMeshProUGUI>().text); 
-                            _dialogueBoxController.AnswerQuestion(2);
-                        });
-                        break;
-                    case 3:
-                        _buttonsSpawned[3].GetComponent<Button>().onClick.AddListener(() => { 
-                            OnAnswer?.Invoke(_buttonsSpawned[3].GetComponentInChildren<TextMeshProUGUI>().text); 
-                            _dialogueBoxController.AnswerQuestion(3);
-                        });
-                        break;
-                    
-                    default:
-                        _buttonsSpawned[0].GetComponent<Button>().onClick.AddListener(() => {
-                            OnAnswer?.Invoke(_buttonsSpawned[0].GetComponentInChildren<TextMeshProUGUI>().text);
-                            _dialogueBoxController.AnswerQuestion(0);
-                        });
-                        break;
-                }
-            }
+            answerButton.GetComponent<Button>().onClick.AddListener(() =>
+            {
+                OnAnswer?.Invoke(answerButton.GetComponentInChildren<TextMeshProUGUI>().text);
+                _dialogueBoxController.AnswerQuestion(_answerButtons.IndexOf(answerButton));
+            });
         }
     }
 
     public void spawnAnswerButtons(Answer[] answers) {
-        for (int i = 0; i < answers.Length; i++)
+        for (int i = 0; i <  answers.Length; i++)
         {
-            // spawn button at location, and set the canvas as the parent
-            Vector3 spawnLocation = getSpawnLocation(answers.Length, i);
-            _buttonsSpawned[i] = Instantiate(_buttonPrefab, spawnLocation, Quaternion.identity);
-            GameObject button = _buttonsSpawned[i];
-            button.transform.SetParent(_parentInCanvas.transform, false);
-            RectTransform buttonTransfrom = button.GetComponent<RectTransform>();
-            Vector3 buttonLocation = new Vector3(spawnLocation.x, spawnLocation.y, spawnLocation.z);
-            buttonTransfrom.localPosition = buttonLocation;
+            _answerButtons[i].SetActive(true);
+            GameObject button = _answerButtons[i];
+
             // fill in the text
             button.GetComponentInChildren<TextMeshProUGUI>().text = answers[i].answerLabel;
         }
+
         // Add onclick listeners
         AddAnswerQuestionNumberListener();
     }
@@ -103,28 +84,19 @@ public class ButtonSpawner : MonoBehaviour
     /// Destroy the button gameobject and remove the button reference in the array
     /// </summary>
     public void removeAllButtons() {
-        for (int i = 0; i < _buttonsSpawned.Count(); i++)
-        {
-            if (_buttonsSpawned[i] != null)
-            {
-                Destroy(_buttonsSpawned[i].gameObject);
-                _buttonsSpawned[i] = null;
-            }
-        }
+        foreach(GameObject button in _answerButtons)
+            button.SetActive(false);
     }
 
     // Add new "Speak" button to start conversation again
     public void spawnSpeakButton(DialogueTree dialogueTree) {
         removeAllButtons();
-        Vector3 spawnLocation = getSpawnLocation(1, 1);
-        _buttonsSpawned[0] = Instantiate(_buttonPrefab, spawnLocation, Quaternion.identity);
+        _buttonsSpawned[0] = Instantiate(_buttonPrefab, _dialogueCanvas.transform);
         GameObject button = _buttonsSpawned[0];
-        button.transform.SetParent(_parentInCanvas.transform, false);
-        RectTransform buttonTransfrom = button.GetComponent<RectTransform>();
-        Vector3 buttonLocation = new Vector3(spawnLocation.x, spawnLocation.y+37f, spawnLocation.z);
-        buttonTransfrom.localPosition = buttonLocation;
+        button.transform.localPosition = Vector3.zero;
         button.GetComponentInChildren<TextMeshProUGUI>().text = "Speak";
-        
+
+        //_dialogueCanvasRect.Set(_dialogueCanvasRect.x, _dialogueCanvasRect.y, 50, 30);
         _buttonsSpawned[0].GetComponent<Button>().onClick.AddListener(() => {_dialogueBoxController.StartDialogue(dialogueTree, 0, "NPC", 0);});
     }
 }

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ButtonSpawner.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.UI;
 using Button = UnityEngine.UI.Button;
 
 public class ButtonSpawner : MonoBehaviour
@@ -11,10 +10,7 @@ public class ButtonSpawner : MonoBehaviour
     [SerializeField] private GameObject _answerButtonContainer;
     [SerializeField] private GameObject _dialogueCanvas;
     [SerializeField] private GameObject _speakButton;
-    private Rect _dialogueCanvasRect;
     [SerializeField] private GameObject _buttonPrefab;
-    // max 4 buttons
-    [HideInInspector] private GameObject[] _buttonsSpawned = new GameObject[4];
     [HideInInspector] private DialogueBoxController _dialogueBoxController;
     [HideInInspector] public static event Action<string> OnAnswer;
 
@@ -22,14 +18,12 @@ public class ButtonSpawner : MonoBehaviour
     private List<UnityAction> _answerButtonActions = new();
     private UnityAction _speakButtonAction = null;
 
-    void Start() {
+    void Start() 
+    {
         _dialogueBoxController = GetComponent<DialogueBoxController>();
-        if (_dialogueBoxController == null ) {
-            Debug.LogError("The NPC missing the DialogueBoxController script");
-        }
         
-        _dialogueCanvasRect = _dialogueCanvas.GetComponent<RectTransform>().rect;
-
+        if (_dialogueBoxController == null )
+            Debug.LogError("The NPC missing the DialogueBoxController script");
 
         foreach (Button child in _answerButtonContainer.GetComponentsInChildren<Button>())
         {
@@ -38,7 +32,11 @@ public class ButtonSpawner : MonoBehaviour
         }
     } 
     
-    void AddAnswerQuestionNumberListener() {
+    /// <summary>
+    /// Add listeners to answer buttons
+    /// </summary>
+    void AddAnswerQuestionNumberListener() 
+    {
         foreach (GameObject answerButton in _answerButtons)
         {
             // storing Unity Action in list before adding listener so it can later be removed
@@ -53,7 +51,13 @@ public class ButtonSpawner : MonoBehaviour
         }
     }
 
-    public void spawnAnswerButtons(Answer[] answers) {
+    /// <summary>
+    /// Enabling an answer button for each provided answer from dialogue tree. 
+    /// More than 4 buttons will result in bad looking formatting/layout, so an error is triggered instead.
+    /// </summary>
+    /// <param name="answers"></param>
+    public void spawnAnswerButtons(Answer[] answers) 
+    {
         if (answers.Length > 4)
         {
             Debug.LogError("There is not room for more than 4 answer buttons in the dialogue canvas, but there are " + answers.Length + " answers in the dialogue tree '" + _dialogueBoxController.dialogueTreeRestart.name + "'!");
@@ -64,6 +68,8 @@ public class ButtonSpawner : MonoBehaviour
         {
             _answerButtons[i].SetActive(true);
             GameObject button = _answerButtons[i];
+
+            // button sometimes won't highlight without setting to false first
             button.GetComponent<Button>().interactable = false;
             button.GetComponent<Button>().interactable = true;
 
@@ -76,9 +82,10 @@ public class ButtonSpawner : MonoBehaviour
     }
 
     /// <summary>
-    /// Destroy the button gameobject and remove the button reference in the array
+    /// Deactivate button objects and remove listeners
     /// </summary>
-    public void removeAllButtons() {
+    public void removeAllButtons() 
+    {
         foreach(GameObject button in _answerButtons)
         {
             if (_answerButtons.IndexOf(button) <= _answerButtonActions.Count - 1)
@@ -98,7 +105,8 @@ public class ButtonSpawner : MonoBehaviour
     }
 
     // Add new "Speak" button to start conversation again
-    public void spawnSpeakButton(DialogueTree dialogueTree) {
+    public void spawnSpeakButton(DialogueTree dialogueTree) 
+    {
         removeAllButtons();
         _speakButton.GetComponentInChildren<TextMeshProUGUI>().text = "Speak";
 

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 // Import of the TTS namespace
 using Meta.WitAi.TTS.Utilities;
 using UnityEngine.Events;
+using UnityEngine.UI;
 
 // This event will be called when the dialogue changes
 [System.Serializable]
@@ -26,6 +27,7 @@ public class DialogueBoxController : MonoBehaviour
     [HideInInspector] private bool _answerTriggered;
     [HideInInspector] private int _answerIndex;
     [SerializeField] private GameObject _skipLineButton;
+    private Button _skipLineButtonComponent;
     [SerializeField] private GameObject _exitButton;
     [SerializeField] private GameObject _speakButton; 
     [HideInInspector] private Animator _animator;
@@ -35,6 +37,7 @@ public class DialogueBoxController : MonoBehaviour
     [HideInInspector] private RectTransform backgroundRect;
     [HideInInspector] private RectTransform dialogueTextRect;
     [HideInInspector] public ButtonSpawner buttonSpawner;
+    private Vector2 _oldDialogueCanvasSizeDelta;
     private string currentDialogue;
     [HideInInspector] public bool dialogueIsActive;
     private int _activatedCount = 0;
@@ -66,6 +69,7 @@ public class DialogueBoxController : MonoBehaviour
             m_DialogueChanged = new DialogueChanged();
         }
 
+        _skipLineButtonComponent = _skipLineButton.GetComponent<Button>();
         _pointingScript = GetComponent<PointingScript>();
         dialogueEnded = false;
         // Assign the event camera
@@ -93,9 +97,9 @@ public class DialogueBoxController : MonoBehaviour
         {
             Debug.LogError("DialogueCanvas not found or does not have a Canvas component!");
         }
+
         // Get the background transform for dimension changes
-        backgroundRect = _dialogueBox.transform.Find("BasicDialogueItems").transform.Find("Background").GetComponent<RectTransform>();
-        dialogueTextRect = _dialogueBox.transform.Find("BasicDialogueItems").transform.Find("DialogueText").GetComponent<RectTransform>();
+        _oldDialogueCanvasSizeDelta = _dialogueCanvas.GetComponent<RectTransform>().sizeDelta;
     }
 
     public void updateAnimator() {
@@ -132,56 +136,57 @@ public class DialogueBoxController : MonoBehaviour
         // Make the "Speak" restart tree the current tree
         dialogueTreeRestart = dialogueTree;
         // Reset the dialogue box dimensions from "Speak" button dimensionsww
-        backgroundRect.sizeDelta = new Vector2(160, 100);
-        dialogueTextRect.sizeDelta = new Vector2(150, 60);
+        _dialogueCanvas.GetComponent<RectTransform>().sizeDelta = _oldDialogueCanvasSizeDelta;
         
         int dialogueSection = 0;
         
         // -1 means that the dialogue was a branchpoint and the script will skip to loading the branchpoint, instead of the standard dialogue when returning to the section
         if (element != -1)
         {
-          for (int i = element; i < dialogueTree.sections[section].dialogue.Length; i++)
-          {
-              _pointingScript.ResetDirection(_animator.transform);
-              _animator.SetBool(_isPointingHash, false);
-              // Start talking animation
-              _animator.SetBool(_isTalkingHash, true);
-              StartCoroutine(revertToIdleAnimation());
-              _dialogueText.text = dialogueTree.sections[section].dialogue[i];
-              _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = true;
-              TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
-              // Invoke the dialogue changed event
-              m_DialogueChanged.Invoke(transform.name, dialogueTreeRestart.name, section, i);
-              _skipLineButton.SetActive(true);
+            for (int i = element; i < dialogueTree.sections[section].dialogue.Length; i++)
+            {
+                _pointingScript.ResetDirection(_animator.transform);
+                _animator.SetBool(_isPointingHash, false);
+                // Start talking animation
+                _animator.SetBool(_isTalkingHash, true);
+                StartCoroutine(revertToIdleAnimation());
+                _dialogueText.text = dialogueTree.sections[section].dialogue[i];
+                _skipLineButtonComponent.interactable = true;
+                _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.normalColor; // give arrow icon child same colour
+                TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
+                // Invoke the dialogue changed event
+                m_DialogueChanged.Invoke(transform.name, dialogueTreeRestart.name, section, i);
+                _skipLineButton.SetActive(true);
 
 
-              // Check if the current section should have disabled the skip line button
-              if (dialogueTree.sections[section].disabkeSkipLineButton)
-              {
-                  _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = false;
-              }
+                // Check if the current section should have disabled the skip line button
+                if (dialogueTree.sections[section].disabkeSkipLineButton)
+                {
+                    _skipLineButtonComponent.interactable = false;
+                    _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.disabledColor; // give arrow icon child same colour
+                }
               
-              // Check if the current dialogue section should have the NPC pointing
-              string pointAt = dialogueTree.sections[section].pointAt;
-              if (pointAt != null && !pointAt.Equals(string.Empty))
-              {
-                  bool directionChanged = _pointingScript.ChangeDirection(dialogueTree.sections[section].pointAt, _animator.transform);
-                  // Make sure the NPC is looking at the object before the pointing animation is started
-                  if (directionChanged)
-                  {
-                      _animator.SetBool(_isTalkingHash, false);
-                      _animator.SetBool(_isPointingHash, true);
-                  }
-              }
+                // Check if the current dialogue section should have the NPC pointing
+                string pointAt = dialogueTree.sections[section].pointAt;
+                if (pointAt != null && !pointAt.Equals(string.Empty))
+                {
+                    bool directionChanged = _pointingScript.ChangeDirection(dialogueTree.sections[section].pointAt, _animator.transform);
+                    // Make sure the NPC is looking at the object before the pointing animation is started
+                    if (directionChanged)
+                    {
+                        _animator.SetBool(_isTalkingHash, false);
+                        _animator.SetBool(_isPointingHash, true);
+                    }
+                }
 
-              while (!_skipLineTriggered)
-              {
-                  _exitButton.SetActive(true);
-                  yield return null;
-              }
-              _skipLineTriggered = false;
-              dialogueSection = section;
-          }   
+                while (!_skipLineTriggered)
+                {
+                    _exitButton.SetActive(true);
+                    yield return null;
+                }
+                _skipLineTriggered = false;
+                dialogueSection = section;
+            }   
         }
 
         string walkTurnDestination = dialogueTree.sections[section].walkOrTurnTowardsAfterDialogue;
@@ -205,10 +210,12 @@ public class DialogueBoxController : MonoBehaviour
         ShowAnswers(dialogueTree.sections[section].branchPoint);
         while (_answerTriggered == false)
         {
-            _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = false;
+            _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.disabledColor; // give arrow icon child same colour
+            _skipLineButtonComponent.interactable = false;
             yield return null;
         }
-        _skipLineButton.GetComponent<UnityEngine.UI.Button>().interactable = true;
+        _skipLineButtonComponent.interactable = true;
+        _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.normalColor; // give arrow icon child same colour
         _answerTriggered = false;
         _exitButton.SetActive(false);
         _skipLineButton.SetActive(false);
@@ -272,6 +279,7 @@ public class DialogueBoxController : MonoBehaviour
     {
         // Reveals the selectable answers and sets their text values
         buttonSpawner.spawnAnswerButtons(branchPoint.answers);
+
         _animator.SetBool(_isPointingHash, false);
         if (_pointingScript != null )
         {
@@ -326,8 +334,7 @@ public class DialogueBoxController : MonoBehaviour
     {
         _dialogueBox.SetActive(true);
         _dialogueText.text = null;
-        backgroundRect.sizeDelta = new Vector2(50,30);
-        dialogueTextRect.sizeDelta = new Vector2(50,30);
+        _dialogueCanvas.GetComponent<RectTransform>().sizeDelta = new Vector2(50, 30);
         buttonSpawner.spawnSpeakButton(dialogueTree);
     }
 }

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -151,7 +151,10 @@ public class DialogueBoxController : MonoBehaviour
                 _animator.SetBool(_isTalkingHash, true);
                 StartCoroutine(revertToIdleAnimation());
                 _dialogueText.text = dialogueTree.sections[section].dialogue[i];
+
+                _skipLineButtonComponent.interactable = false;
                 _skipLineButtonComponent.interactable = true;
+
                 _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.normalColor; // give arrow icon child same colour
                 TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
                 // Invoke the dialogue changed event
@@ -214,7 +217,9 @@ public class DialogueBoxController : MonoBehaviour
             _skipLineButtonComponent.interactable = false;
             yield return null;
         }
+
         _skipLineButtonComponent.interactable = true;
+
         _skipLineButton.transform.GetChild(0).GetComponent<Image>().color = _skipLineButtonComponent.colors.normalColor; // give arrow icon child same colour
         _answerTriggered = false;
         _exitButton.SetActive(false);

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -34,11 +34,8 @@ public class DialogueBoxController : MonoBehaviour
     [HideInInspector] private int _isTalkingHash;
     [HideInInspector] private int _hasNewDialogueOptionsHash;
     [HideInInspector] private int _isPointingHash;
-    [HideInInspector] private RectTransform backgroundRect;
-    [HideInInspector] private RectTransform dialogueTextRect;
     [HideInInspector] public ButtonSpawner buttonSpawner;
     private Vector2 _oldDialogueCanvasSizeDelta;
-    private string currentDialogue;
     [HideInInspector] public bool dialogueIsActive;
     private int _activatedCount = 0;
     [HideInInspector]public DialogueTree dialogueTreeRestart;
@@ -152,6 +149,7 @@ public class DialogueBoxController : MonoBehaviour
                 StartCoroutine(revertToIdleAnimation());
                 _dialogueText.text = dialogueTree.sections[section].dialogue[i];
 
+                // button sometimes won't highlight without setting to false first
                 _skipLineButtonComponent.interactable = false;
                 _skipLineButtonComponent.interactable = true;
 

--- a/Assets/VR4VET/Components/PauseMenu/Prefabs/Main Menu v3 Canvases.prefab
+++ b/Assets/VR4VET/Components/PauseMenu/Prefabs/Main Menu v3 Canvases.prefab
@@ -1172,9 +1172,9 @@ RectTransform:
   m_Father: {fileID: 463845737693947452}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.6, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 49.5, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &646092130126286363
@@ -2238,9 +2238,9 @@ RectTransform:
   m_Father: {fileID: 7659903979766159183}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 69.4, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 23.8, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &646092131552328439
@@ -2720,9 +2720,9 @@ RectTransform:
   m_Father: {fileID: 2718321197750475754}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 73.55, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 52.6, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &646092132109846133
@@ -10600,9 +10600,9 @@ RectTransform:
   m_Father: {fileID: 2718321197750475754}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 34.15, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 18, y: 18}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8553755642822070854
@@ -16486,9 +16486,9 @@ RectTransform:
   m_Father: {fileID: 463845737693947452}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 33.649998, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 18, y: 18}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8876579221651266712
@@ -16861,9 +16861,9 @@ RectTransform:
   m_Father: {fileID: 7659903979766159183}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 44.7, y: -17.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 18, y: 18}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6296636488960505477

--- a/Assets/VR4VET/Components/Tablet/Prefabs/NewUpdatedTablet.prefab
+++ b/Assets/VR4VET/Components/Tablet/Prefabs/NewUpdatedTablet.prefab
@@ -8231,9 +8231,9 @@ RectTransform:
   m_Father: {fileID: 6940568040039820520}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 279.119, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1807655772057958613
@@ -9147,6 +9147,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 173510b635fd8e14f9c139e33d621964, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ExcludeObjects: []
 --- !u!114 &3885051581141841664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17233,9 +17234,9 @@ RectTransform:
   m_Father: {fileID: 6940568040039820520}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 279.119, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &5008978225352522088
@@ -18758,6 +18759,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4900130581286817621}
     m_Modifications:
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.r
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5253579016265242522, guid: b8926673bae545c44a90429a4c7f5a98,
         type: 3}
       propertyPath: m_Name
@@ -18946,6 +18962,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2831056426761588793}
     m_Modifications:
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2892865667784607864, guid: b8926673bae545c44a90429a4c7f5a98,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.r
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5253579016265242522, guid: b8926673bae545c44a90429a4c7f5a98,
         type: 3}
       propertyPath: m_Name

--- a/Assets/VR4VET/Components/Tablet/UI/Textures/Tablet UI(New)/Arrow_Icon.png
+++ b/Assets/VR4VET/Components/Tablet/UI/Textures/Tablet UI(New)/Arrow_Icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0ed17249b5cc2796d55a561d8c560c7b1ae2b6f5aeb85345d78524d60b11042
+size 7335

--- a/Assets/VR4VET/Components/Tablet/UI/Textures/Tablet UI(New)/Arrow_Icon.png.meta
+++ b/Assets/VR4VET/Components/Tablet/UI/Textures/Tablet UI(New)/Arrow_Icon.png.meta
@@ -1,0 +1,134 @@
+fileFormatVersion: 2
+guid: 5b2af041ef5785f4f95c2930c2320ca7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 1
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VR4VET/Components/TextToSpeechButton/Scripts/TextToSpeechButton.cs
+++ b/Assets/VR4VET/Components/TextToSpeechButton/Scripts/TextToSpeechButton.cs
@@ -16,6 +16,8 @@ public class TextToSpeechButton : MonoBehaviour
     [SerializeField] private GameObject TTSSpeaker;
     private TTSSpeaker _speaker;
 
+    private Button _button;
+
     [Tooltip("Place children speaker icons here in increasing order (speaker without sound waves at index 0)")]
     [SerializeField] private List<Image> SpeakerIcons;
 
@@ -49,6 +51,7 @@ public class TextToSpeechButton : MonoBehaviour
     {
         // fetching the text-to-speech object
         _speaker = TTSSpeaker.GetComponentInChildren<TTSSpeaker>();
+        _button = GetComponent<Button>();
     }
 
     /// <summary>
@@ -57,6 +60,10 @@ public class TextToSpeechButton : MonoBehaviour
     private float buttonPressTime = Mathf.NegativeInfinity;
     public void PlayTTS()
     {
+        // doing this makes highlighting (when hovering pointer on button) work again after pressing button
+        _button.interactable = false;
+        _button.interactable = true;
+
         // Prevent unwanted double clicks
         if (Time.realtimeSinceStartup - buttonPressTime < .4)
             return;

--- a/Assets/VR4VET/Components/TextToSpeechButton/UI/SpeakerButton.prefab
+++ b/Assets/VR4VET/Components/TextToSpeechButton/UI/SpeakerButton.prefab
@@ -60,7 +60,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -136,7 +136,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -345,7 +345,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}

--- a/Assets/VR4VET/Components/ToolTips/Prefabs/SimpleToolTip.prefab
+++ b/Assets/VR4VET/Components/ToolTips/Prefabs/SimpleToolTip.prefab
@@ -184,7 +184,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
@@ -205,7 +205,31 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 5360422000855830891}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 5360422000855830890}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Selectable, UnityEngine.UI
+        m_MethodName: set_interactable
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5360422000855830890}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Selectable, UnityEngine.UI
+        m_MethodName: set_interactable
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!1 &5360422000931054188
 GameObject:
   m_ObjectHideFlags: 0
@@ -371,7 +395,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 20
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &5360422001454874244
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -530,8 +554,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f5d153ad7d5d384e8c8c574efb91b74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  graphicRaycasters:
-  - {fileID: 5360422001454874244}
 --- !u!1 &5360422001577558892
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Accessibility features and performance improvement.


* **What is the current behavior?**
The laboratory scene runs at or slightly below 60fps on Quest 2 most of the time, which is too low for Meta Store's requirements (#825).

  Many UI elements lack a higher contrast mode, like the NPC's dialogue box, the laboratory's microscope. (#822).  


* **What is the new behavior?**
The laboratory scene now runs at a mostly stable 72 fps, with a few exceptions when things are loading.

  The NPC dialogue box buttons now turns darker when higher contrast mode is selected. They are also a bit larger now by default. 

  Buttons now highlight in the laboratory, including the interactive images on the posters (of which there are more of now  - the images on the note sheet are also interactive now). The images now return to normal size by themselves after 10 seconds to prevent them permanently covering the text information if the player doesn't know how to minimize them again.

  The note sheet now reacts to larger text mode and scales UI up a little. 

  The text-to-speech buttons (except for the ones on the tablet, since those are touch only) also highlight when pointed at.

  The microscope UI buttons are outlined, and uses the VR4VET purple brand colour.

* **Does this PR introduce a breaking change?**
No, highly unlikely.

* **Other information**:
Some code has been optimized a little. For example, ButtonSpawner.cs now attempts to remove listeners from the dialogue box's answer buttons when the are removed, and they are no longer instantiated and destroyed, but simply hidden and unhidden when needed.
