### PR TITLE
Feeding score UI fix

### DIFF
--- a/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
+++ b/Assets/FishFeeding/Components/MerdCamera/Prefabs/MerdCameraJoystick.prefab
@@ -397,30 +397,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ced152fad2fb9a24893900939325d5ce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LargerTextComponentSettings:
-  - TextComponentType: 0
-    TMPTextComponent: {fileID: 6731464513209113797}
-    UnityEngineUITextComponent: {fileID: 0}
-    FontSize: 70
-    Scale: 0
+  LargerTextComponentSettings: []
+  LargerUnityUIObjectsSettings:
+  - Object: {fileID: 106238766030278490}
+    Scale: 1.2
     Width: 0
     Height: 0
+    Position: {x: 0, y: 0, z: 0}
     OldFontSize: 0
     OldWidth: 0
     OldHeight: 0
     OldScale: {x: 0, y: 0, z: 0}
-  - TextComponentType: 0
-    TMPTextComponent: {fileID: 106238766075695482}
-    UnityEngineUITextComponent: {fileID: 0}
-    FontSize: 70
-    Scale: 0
-    Width: 0
-    Height: 0
-    OldFontSize: 0
-    OldWidth: 0
-    OldHeight: 0
-    OldScale: {x: 0, y: 0, z: 0}
-  LargerUnityUIObjectsSettings: []
+    OldPosition: {x: 0, y: 0, z: 0}
 --- !u!1 &8377748996439984917
 GameObject:
   m_ObjectHideFlags: 0
@@ -926,21 +914,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 9117139461951565463}
     m_Modifications:
-    - target: {fileID: 1509832706384064440, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_text
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1509832706384064440, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_margin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1509832706384064443, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1509832706384064443, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -954,12 +927,7 @@ PrefabInstance:
     - target: {fileID: 1509832706384064443, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 1509832706384064443, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 41.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1509832706384064443, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
@@ -973,13 +941,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1509832706438263193, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 322.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1509832706438263193, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 211.39
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1509832706639622045, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
@@ -1068,17 +1031,7 @@ PrefabInstance:
       objectReference: {fileID: 1698565875983136099}
     - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
@@ -1089,11 +1042,6 @@ PrefabInstance:
     - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4159521727139849890, guid: df5519ec99828134a9a8dcac58762c6c,
@@ -1106,31 +1054,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_text
-      value: 'YOUR SCORE:'
-      objectReference: {fileID: 0}
-    - target: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_fontSize
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_fontSizeBase
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_verticalMapping
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
-      propertyPath: m_VerticalAlignment
-      value: 512
-      objectReference: {fileID: 0}
     - target: {fileID: 5389205961703176169, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -1163,18 +1086,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5569032857749188760, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 320
-      objectReference: {fileID: 0}
-    - target: {fileID: 5569032857749188760, guid: df5519ec99828134a9a8dcac58762c6c,
-        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5569032857749188760, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 161.05
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5569032857749188760, guid: df5519ec99828134a9a8dcac58762c6c,
         type: 3}
@@ -1224,18 +1142,12 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 3133748046385925914, guid: df5519ec99828134a9a8dcac58762c6c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: df5519ec99828134a9a8dcac58762c6c, type: 3}
---- !u!114 &106238766075695482 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1509832706384064440, guid: df5519ec99828134a9a8dcac58762c6c,
+--- !u!1 &106238766030278490 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1509832706438263192, guid: df5519ec99828134a9a8dcac58762c6c,
     type: 3}
   m_PrefabInstance: {fileID: 1553019769850478274}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &106238766902792480 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1509832706639622114, guid: df5519ec99828134a9a8dcac58762c6c,
@@ -1252,18 +1164,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dd123eb165a94d348b1ee46ff6932428, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6731464513209113797 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5253334683913200135, guid: df5519ec99828134a9a8dcac58762c6c,
-    type: 3}
-  m_PrefabInstance: {fileID: 1553019769850478274}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &2559071664005627028

--- a/Assets/FishFeeding/Components/Score/Prefabs/MonitorScore.prefab
+++ b/Assets/FishFeeding/Components/Score/Prefabs/MonitorScore.prefab
@@ -26,17 +26,17 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1509832706384064442}
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.000113248825}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1509832706438263193}
+  m_Father: {fileID: 5569032857749188760}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -200, y: -250}
+  m_SizeDelta: {x: 0, y: 46.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1509832706384064441
 CanvasRenderer:
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 1
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -129,7 +129,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 57.54161, z: 0, w: 0}
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -163,18 +163,17 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1509832706438263192}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.0385}
-  m_LocalScale: {x: 0.00082548824, y: 0.00058797275, z: 0.000625}
-  m_ConstrainProportionsScale: 0
+  m_LocalPosition: {x: 0, y: 0, z: -0.0303}
+  m_LocalScale: {x: 0.0008254882, y: 0.0005879727, z: 0.0006249999}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 5569032857749188760}
-  - {fileID: 1509832706384064443}
   m_Father: {fileID: 1509832706639622114}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.002, y: -0.003}
+  m_AnchoredPosition: {x: 0.002, y: -0.0277}
   m_SizeDelta: {x: 800, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &1509832706438263196
@@ -583,13 +582,14 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4159521727139849890}
+  - {fileID: 1509832706384064443}
   m_Father: {fileID: 1509832706438263193}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 400, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 321.4, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2275799863400833920
 CanvasRenderer:
@@ -617,11 +617,11 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 0
+  m_Spacing: 22
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
+  m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -675,7 +675,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 44.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2788114777562205979
 CanvasRenderer:

--- a/Assets/FishFeeding/Scenes/FishFeeding.unity
+++ b/Assets/FishFeeding/Scenes/FishFeeding.unity
@@ -20645,22 +20645,22 @@ PrefabInstance:
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 75.6
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 646092130593344025, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -20765,22 +20765,22 @@ PrefabInstance:
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 69.4
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 646092131574781501, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -20825,22 +20825,22 @@ PrefabInstance:
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 73.55
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 704264033538043867, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -20865,22 +20865,22 @@ PrefabInstance:
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 34.15
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 1362919669926270899, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -20962,6 +20962,56 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2028798707719612320, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028798707719612320, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028798707719612320, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028798707719612320, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028798707719612320, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2263651124080325555, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2263651124080325555, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2263651124080325555, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2263651124080325555, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2263651124080325555, guid: 04ece6a94084081468c6e6891c807871,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2446061527338701380, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -21030,42 +21080,42 @@ PrefabInstance:
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 44.7
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 33.649998
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 3711358385918375471, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -24382,11 +24432,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3185445412016756832, guid: 12ee6c50f9832c247a378f804297c417,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3185445412016756832, guid: 12ee6c50f9832c247a378f804297c417,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -26142,11 +26187,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396310627136491098, guid: 12ee6c50f9832c247a378f804297c417,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6396310627136491098, guid: 12ee6c50f9832c247a378f804297c417,
         type: 3}

--- a/Assets/VR4VET/Components/ControllerToolTips/Scripts/ControllerTooltipManager.cs
+++ b/Assets/VR4VET/Components/ControllerToolTips/Scripts/ControllerTooltipManager.cs
@@ -87,7 +87,7 @@ public class ControllerTooltipManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Scans through objects in each hand's list of objects in its vicinity (those activating tooltips)
+    /// Looks for tooltip activators within a 0.05 radius of the player's grabber
     /// and decides which one is closest. It then activates that object's relevant tooltips.
     /// Runs several times a second.
     /// </summary>
@@ -105,12 +105,14 @@ public class ControllerTooltipManager : MonoBehaviour
         }
 
         Grabber grabber = controllerHand == ControllerHand.Left ? _grabberLeft : _grabberRight; // figure out which hand
+
+        // once hand is figured out the following code (targeting that hand) runs several times a second
         while (true)
         {
-            if (_accessibilityEnabled)
+            if (_accessibilityEnabled && !grabber.HeldGrabbable) // if tooltips are disabled or this hand holds something -> don't look for surrounding objects, close all tooltips
             {
                 bool deactivated = false;
-                int numOverlaps = Physics.OverlapSphereNonAlloc(grabber.transform.position, .05f, _surroundingColliders); // finding surrounding colliders, and storing the amount to not iterate to "invalid" indicies
+                int numOverlaps = Physics.OverlapSphereNonAlloc(grabber.transform.position, .05f, _surroundingColliders); // finding surrounding colliders (radius .05 is the same as grabber), and storing the amount to not iterate to "invalid" indicies
 
                 List<ControllerTooltipActivator> activators = new(); 
                 for (int i = 0; i < numOverlaps; i++)
@@ -178,6 +180,7 @@ public class ControllerTooltipManager : MonoBehaviour
     /// This is used to hide tooltips and Quest hand controller models when the player presses one of the related buttons.
     /// Note: the oculus system buttons (the recessed buttons used to navigate the operating system or device) will not trigger this behaviour!
     /// </summary>
+    /// <param name="activator"></param>
     /// <param name="controllerHand"></param>
     /// <returns></returns>
     private bool TooltippedButtonsDown(ControllerTooltipActivator activator, ControllerHand controllerHand)
@@ -212,7 +215,7 @@ public class ControllerTooltipManager : MonoBehaviour
     /// Takes a list of mappings between Quest controller buttons and their actions.
     /// Activates tooltips that hover above each button showing their actions for an object.
     /// </summary>
-    /// <param name="interractableObject"></param>
+    /// <param name="buttonActionMappings"></param>
     /// <param name="controllerHand"></param>
     private void SetUpTooltips(List<ButtonActionMapping> buttonActionMappings, ControllerHand controllerHand)
     {
@@ -224,7 +227,7 @@ public class ControllerTooltipManager : MonoBehaviour
 
         foreach (ButtonActionMapping mapping in buttonActionMappings)
         {
-            // find the correct button model before configuring its tooltip
+            // find the correct button model (on the provided hand) before configuring its tooltip
             Transform button = controllerHand == ControllerHand.Left
             ?
             mapping.Button switch
@@ -315,6 +318,7 @@ public class ControllerTooltipManager : MonoBehaviour
 
     /// <summary>
     /// Activates Quest hand controller models
+    /// <param name="controllerHand"/>
     /// </summary>
     private void SetQuestControllerModels(ControllerHand controllerHand)
     {
@@ -572,6 +576,11 @@ public class ControllerTooltipManager : MonoBehaviour
             return distY >= 0 ? tooltipScript.AnchorBottom() : tooltipScript.AnchorTop(); // return bottom edge if positioned above, top otherwise
     }
 
+    /// <summary>
+    /// Keeps track of how many tooltips are currently open
+    /// and enable Quest controller hand model
+    /// </summary>
+    /// <param name="controllerHand"></param>
     public void OnTooltipStartOpening(ControllerHand controllerHand)
     {
         if (controllerHand == ControllerHand.None)
@@ -586,16 +595,6 @@ public class ControllerTooltipManager : MonoBehaviour
     }
 
     /// <summary>
-    /// This is called when a tooltip has finished moving "out of" the controller.
-    /// </summary>
-    /// <param name="controllerHand"></param>
-    public void OnTooltipOpened(ControllerHand controllerHand)
-    {
-        if (controllerHand == ControllerHand.None)
-            Debug.LogError("Tooltip must have HandSide set to either left or right, but was " + controllerHand.ToString() + "!");
-    }
-
-    /// <summary>
     /// This is called when a tooltip has moved "back into" the controller, signalling that it may be time to hide the Quest controller
     /// and show the player's hand again (if the player's hand is not intersecting with any ControllerTooltipActivators).
     /// </summary>
@@ -605,11 +604,13 @@ public class ControllerTooltipManager : MonoBehaviour
         if (controllerHand == ControllerHand.None)
             Debug.LogError("Tooltip must have HandSide set to either left or right, but was " + controllerHand.ToString() + "!");
 
+        // decrease active tooltips by one, but make sure it is not negative
         if (controllerHand == ControllerHand.Left)
-            _tooltipsActiveLeft = (_tooltipsActiveLeft - 1 >= 0) ? _tooltipsActiveLeft - 1 : 0;
+            _tooltipsActiveLeft = Mathf.Max(_tooltipsActiveLeft - 1, 0);
         if (controllerHand == ControllerHand.Right)
-            _tooltipsActiveRight = (_tooltipsActiveRight - 1 >= 0) ? _tooltipsActiveRight - 1 : 0;
+            _tooltipsActiveRight = Mathf.Max(_tooltipsActiveRight - 1, 0);
 
+        // show standard hand model if no tooltips
         if (_tooltipsActiveLeft <= 0)
             SetDefaultHandModel(ControllerHand.Left);
         if (_tooltipsActiveRight <= 0)
@@ -649,6 +650,10 @@ public class ControllerTooltipManager : MonoBehaviour
         }  
     }
 
+    /// <summary>
+    /// This is called when setting is changed or loaded from Pause Menu.
+    /// </summary>
+    /// <param name="isOn"></param>
     public void OnPauseMenuToggledLabelTeleport(bool isOn)
     {
         _alwaysLabelTeleport = isOn;

--- a/Assets/VR4VET/Components/ControllerToolTips/Scripts/HandControllerToolTip.cs
+++ b/Assets/VR4VET/Components/ControllerToolTips/Scripts/HandControllerToolTip.cs
@@ -69,8 +69,6 @@ public class HandControllerToolTip : MonoBehaviour
             GetComponent<LineRenderer>().enabled = false;
             _controllerTooltipManager.OnTooltipClosed(HandSide);
         }
-        else
-            _controllerTooltipManager.OnTooltipOpened(HandSide);
     }
 
     /// <summary>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
  - Bug fixes

* **What is the current behavior?** 
  - The Fish Feeding scenario's scoring monitor content does not scale properly and overlaps (#836).
  - The teleport controller tooltip appears even when the player's left hand is holding a grabbable object. This happens when the grabbing hand is snapped to an object and the player pulls the hand away from the object. The grabber follows the player's hand, thus making the tooltip system not detect any surrounding objects. The default teleport tooltip then appears (#837).

* **What is the new behavior?** (if this is a feature change)
  - The monitor in the Fish Feeding scenario is fixed.
  - A hand's tooltips will now deactive when holding something. This means that no tooltips will appear no matter where the grabber is positioned, thus fixing the problem.

* **Does this PR introduce a breaking change?**
  - No.