### PR TITLE
Chat service function calls

### DIFF
--- a/Assets/FishFactory/Scripts/SceneLogic/SceneController.cs
+++ b/Assets/FishFactory/Scripts/SceneLogic/SceneController.cs
@@ -63,7 +63,7 @@ public class SceneController : MonoBehaviour
     /// Change the scene. If the player is currently in the HSE room the requirements has to be fulfilled first.
     /// </summary>
     /// <param name="scene">The name of the scene to change to</param>
-    private void ChangeScene(string scene)
+    public void ChangeScene(string scene)
     {
 
         // Check if the player is in the HSE room and if the requirements are fulfilled. Player should only be able to progress after the HSE room is completed or if going to a non-factory scene.

--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -154,9 +154,11 @@ public class AIRequest : MonoBehaviour
                             Debug.Log($"AIRequest: Function call detected: {response.function_call.function_name}");
                             ExecuteFunction(response.function_call.function_name, response.function_call.function_parameters);
                         }
-
-                        // Trigger TTS and UI Update
-                        HandleSuccessfulResponse(sanitizedResponseText);
+                        if (response.function_call.function_name != "teleport")
+                        {
+                            // Trigger TTS and UI Update
+                            HandleSuccessfulResponse(sanitizedResponseText);
+                        }
                     }
                 }
                 catch (Exception e)

--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -149,6 +149,12 @@ public class AIRequest : MonoBehaviour
 
                         Debug.Log($"AI Response: {sanitizedResponseText}");
 
+                        if (response.function_call != null)
+                        {
+                            Debug.Log($"AIRequest: Function call detected: {response.function_call.function_name}");
+                            ExecuteFunction(response.function_call.function_name, response.function_call.function_parameters);
+                        }
+
                         // Trigger TTS and UI Update
                         HandleSuccessfulResponse(sanitizedResponseText);
                     }
@@ -220,5 +226,41 @@ public class AIRequest : MonoBehaviour
             "nl" => " Sorry, er is iets misgegaan. Probeer het opnieuw.",
             _ => " I'm sorry, something went wrong. Please try again.",
         };
+    }
+
+    private void ExecuteFunction(string functionName, string[] parameters)
+    {
+        switch (functionName)
+        {
+            case "teleport":
+                string location = parameters[0];
+                Debug.Log($"Function case teleport to {location}");
+                TeleportPlayer(location);
+                break;
+
+            case "showObject":
+                string objectId = parameters[0];
+                Debug.Log($"Showing object");
+                /*HighlightObject(objectId);*/
+                break;
+
+            default:
+                Debug.LogWarning($"Unknown function: {functionName}");
+                break;
+        }
+    }
+
+    private void TeleportPlayer(string location)
+    {
+        Debug.Log($"Teleporting player to {location}");
+        SceneController sceneController = FindObjectOfType<SceneController>();
+        if (sceneController != null)
+        {
+            sceneController.ChangeScene(location);
+        }
+        else
+        {
+            Debug.LogError("SceneController not found. Cannot teleport player.");
+        }
     }
 }

--- a/Assets/VR4VET/Components/NPC/AI/OpenAIResponseSerializer.cs
+++ b/Assets/VR4VET/Components/NPC/AI/OpenAIResponseSerializer.cs
@@ -64,10 +64,18 @@ public class  LLMResponse
     public Usage usage;
     public string system_fingerprint;
 
+    public FunctionCall function_call;
     public string response => choices?.FirstOrDefault()?.message.content;
 
     public List<string> context_used;
     public Dictionary<string, object> metadata;
+}
+
+[Serializable]
+public class FunctionCall
+{
+    public string function_name;
+    public string[] function_parameters;
 }
 
 [Serializable]


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Makes changes to AIRequest to call functions if they are added to response from chatservice. User can ask to teleport to different scenes.

* **What is the current behavior?** (You can also link to an open issue here)
NPC can't make any function calls.

* **What is the new behavior?** (if this is a feature change)
NPC has ability to teleport user to Laboratory or ReceptionOutdoor. User can't teleport to a scene if they are already in it. NPC will ask user to confirm whether they want to be teleported or not.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Surely not, right?

* **Other information**:
I was a bit unsure about setting the ChangeScene function in SceneController to public, but hopefully it is fine. The way AIRequest finds the SceneController is also a bit odd, but it works so we ball.
