### PR TITLE
feat: add specialized behaviour script to larry npc that reduces dial…

### DIFF
--- a/Assets/Laboratory/Prefabs/NPC/LabratoryLars.asset
+++ b/Assets/Laboratory/Prefabs/NPC/LabratoryLars.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   runtimeAnimatorController: {fileID: 9100000, guid: acb4b9981fa45ce46adb4867634b31ab,
     type: 2}
   SpatialBlend: 0
-  MinDistance: 0
+  MinDistance: 1
   GlobalChatMemory: 1
   isAiNpc: 1
   WitVoiceId: 0

--- a/Assets/Laboratory/Scenes/Laboratory.unity
+++ b/Assets/Laboratory/Scenes/Laboratory.unity
@@ -77416,6 +77416,19 @@ MonoBehaviour:
   m_OnDissectingFishClicked:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1455570850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455570841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a57e60bea82b694180a8db11ca2eafd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  triggerDistance: 2.5
 --- !u!1 &1455755823
 GameObject:
   m_ObjectHideFlags: 0
@@ -92233,22 +92246,22 @@ PrefabInstance:
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 75.6
       objectReference: {fileID: 0}
     - target: {fileID: 646092130126286341, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 646092130593344025, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -92353,22 +92366,22 @@ PrefabInstance:
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 69.4
       objectReference: {fileID: 0}
     - target: {fileID: 646092131552328433, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 646092131574781501, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -92413,22 +92426,22 @@ PrefabInstance:
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 73.55
       objectReference: {fileID: 0}
     - target: {fileID: 646092132109846135, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 704264033538043867, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -92453,22 +92466,22 @@ PrefabInstance:
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 34.15
       objectReference: {fileID: 0}
     - target: {fileID: 1104997758399786754, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 1362919669926270899, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
@@ -92668,42 +92681,42 @@ PrefabInstance:
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 44.7
       objectReference: {fileID: 0}
     - target: {fileID: 3403291273372931831, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 33.649998
       objectReference: {fileID: 0}
     - target: {fileID: 3482202683152220665, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17.5
       objectReference: {fileID: 0}
     - target: {fileID: 3711358385918375471, guid: 04ece6a94084081468c6e6891c807871,
         type: 3}

--- a/Assets/Laboratory/Scripts/SpecializedBehaviourLarry.cs
+++ b/Assets/Laboratory/Scripts/SpecializedBehaviourLarry.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.XR.CoreUtils;
+using UnityEngine;
+
+public class SpecializedBehaviourLarry : MonoBehaviour
+{
+    [SerializeField]
+    public float triggerDistance = 2.5f; // Distance to trigger the dialogue
+
+    private NPCSpawner _npcSpawner;
+    private GameObject _larryNpc;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        _npcSpawner = GetComponent<NPCSpawner>();
+        if (_npcSpawner == null)
+        {
+            Debug.LogError("No NPCSpawner found");
+            return;
+        }
+
+        _larryNpc = _npcSpawner._npcInstances[0];
+
+        // Reduce dialogue trigger radius to avoid TTSSpeaker component missing error from spawning inside NPC dialogue trigger distance
+        CapsuleCollider capsuleCollider = _larryNpc.GetNamedChild("CollisionTriggerHandler").GetComponent<CapsuleCollider>();
+        capsuleCollider.radius = triggerDistance;
+    }
+}

--- a/Assets/Laboratory/Scripts/SpecializedBehaviourLarry.cs.meta
+++ b/Assets/Laboratory/Scripts/SpecializedBehaviourLarry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a57e60bea82b694180a8db11ca2eafd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
…ogue trigger distance, to avoid TTSSpeaker missing error

<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds specialized behavior to Larry in the Laboratory to have a adjustable dialogue trigger radius in order to avoid an error when spawning inside the trigger area.

* **What is the current behavior?** (You can also link to an open issue here)
Currently you get an error that TTSSpeaker is missing error from spawning in range of Larry's dialogue trigger without TTSSpeaker having been initialized yet, so the initial dialogue portion will have no audio.

* **What is the new behavior?** (if this is a feature change)
Larry won't start speaking until you get a little closer to him, and the beg mentioned above is gone.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
The branch name for this doesn't make any sense, but we ball
